### PR TITLE
Escape bash variables in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,10 @@
 #   3. Cloud Run env vars to enable the KB at runtime
 #      (BOOMI_DOCS_ENABLED, BOOMI_DOCS_DB_PATH, BOOMI_DOCS_RELEASE_TAG).
 #
-# Substitutions match the existing trigger so the migration is value-stable.
+# NOTE: bash-only variables (e.g. $$TAG, $${KB_RELEASE_TAG:-}) are escaped
+# with $$ so Cloud Build leaves them alone during its pre-execution
+# substitution pass. Single-$ references like $_AR_HOSTNAME, $COMMIT_SHA,
+# $REPO_NAME, $BUILD_ID are resolved by Cloud Build before bash runs.
 
 substitutions:
   _AR_HOSTNAME: us-central1-docker.pkg.dev
@@ -45,12 +48,12 @@ steps:
         set -a
         . deploy/kb-release.env
         set +a
-        if [ -z "${KB_RELEASE_TAG:-}" ]; then
+        if [ -z "$${KB_RELEASE_TAG:-}" ]; then
           echo "ERROR: KB_RELEASE_TAG is empty in deploy/kb-release.env." >&2
           exit 1
         fi
-        printf '%s' "$KB_RELEASE_TAG" > /workspace/kb_release_tag
-        echo "Pinned KB release: $KB_RELEASE_TAG"
+        printf '%s' "$$KB_RELEASE_TAG" > /workspace/kb_release_tag
+        echo "Pinned KB release: $$KB_RELEASE_TAG"
 
   - id: PreflightKBAsset
     name: gcr.io/cloud-builders/curl
@@ -60,10 +63,10 @@ steps:
       - -c
       - |
         set -euo pipefail
-        TAG="$(cat /workspace/kb_release_tag)"
-        URL="https://github.com/RenEra-ai/knowledge-base-builder/releases/download/${TAG}/boomi_knowledge_db.tar.gz"
-        echo "Preflight HEAD $URL"
-        curl -fIL --retry 3 --retry-delay 2 "$URL" >/dev/null
+        TAG="$$(cat /workspace/kb_release_tag)"
+        URL="https://github.com/RenEra-ai/knowledge-base-builder/releases/download/$${TAG}/boomi_knowledge_db.tar.gz"
+        echo "Preflight HEAD $$URL"
+        curl -fIL --retry 3 --retry-delay 2 "$$URL" >/dev/null
 
   - id: Build
     name: gcr.io/cloud-builders/docker
@@ -73,12 +76,12 @@ steps:
       - -c
       - |
         set -euo pipefail
-        TAG="$(cat /workspace/kb_release_tag)"
+        TAG="$$(cat /workspace/kb_release_tag)"
         IMAGE="$_AR_HOSTNAME/$_AR_PROJECT_ID/$_AR_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
         docker build \
           --no-cache \
-          --build-arg "KB_RELEASE_TAG=$TAG" \
-          -t "$IMAGE" \
+          --build-arg "KB_RELEASE_TAG=$$TAG" \
+          -t "$$IMAGE" \
           -f Dockerfile \
           .
 
@@ -97,14 +100,14 @@ steps:
       - -c
       - |
         set -euo pipefail
-        TAG="$(cat /workspace/kb_release_tag)"
+        TAG="$$(cat /workspace/kb_release_tag)"
         IMAGE="$_AR_HOSTNAME/$_AR_PROJECT_ID/$_AR_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
         gcloud run services update "$_SERVICE_NAME" \
           --platform=managed \
-          --image="$IMAGE" \
+          --image="$$IMAGE" \
           --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID \
           --region=$_DEPLOY_REGION \
-          --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$TAG" \
+          --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$$TAG" \
           --quiet
 
 images:


### PR DESCRIPTION
## Problem

The first build off the migrated trigger (`08780891-3db4-41e3-b6a0-754e82baa8d9`) failed immediately with:

\`\`\`
generic::invalid_argument: invalid value for 'build.substitutions':
key in the template "KB_RELEASE_TAG" is not a valid built-in substitution
\`\`\`

Cloud Build runs a substitution pass over the entire YAML *before* any step starts. Bash variables inside heredocs (`$TAG`, `$KB_RELEASE_TAG`, `$URL`, `$IMAGE`) were being interpreted as substitution references. They are neither built-ins (`$COMMIT_SHA`, `$REPO_NAME`, ...) nor user substitutions (which must start with `_`), so the build fails parse-validation even with `substitutionOption: ALLOW_LOOSE` — `ALLOW_LOOSE` covers undefined user substitutions, not unknown built-ins.

## Fix

Escape every bash-local `$` to `$$` so Cloud Build leaves it untouched and bash sees a literal `$`:

- `$KB_RELEASE_TAG` → `$$KB_RELEASE_TAG`
- `${KB_RELEASE_TAG:-}` → `$${KB_RELEASE_TAG:-}`
- `$TAG` / `$URL` / `$IMAGE` → `$$TAG` / `$$URL` / `$$IMAGE`
- `$(cat ...)` → `$$(cat ...)`

Single-`$` references that genuinely *should* be Cloud Build substitutions stay as-is: `$_AR_HOSTNAME`, `$_AR_PROJECT_ID`, `$_AR_REPOSITORY`, `$_SERVICE_NAME`, `$_DEPLOY_REGION`, `$_TRIGGER_ID`, `$COMMIT_SHA`, `$BUILD_ID`, `$REPO_NAME`. These are resolved by Cloud Build before bash runs.

Added a comment block at the top of the file documenting the convention so future edits don't reintroduce the bug.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('cloudbuild.yaml'))"` → OK
- [ ] Merge fires trigger; build reaches `LoadKBPin` step instead of failing at parse
- [ ] `PreflightKBAsset` succeeds against `kb-13`
- [ ] `Build` step passes `--build-arg KB_RELEASE_TAG=kb-13` to Docker
- [ ] `Deploy` step sets `BOOMI_DOCS_ENABLED=true`, `BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db`, `BOOMI_DOCS_RELEASE_TAG=kb-13` on Cloud Run