### PR TITLE
Raise Cloud Run memory to 2Gi for KB-enabled image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -102,11 +102,15 @@ steps:
         set -euo pipefail
         TAG="$$(cat /workspace/kb_release_tag)"
         IMAGE="$_AR_HOSTNAME/$_AR_PROJECT_ID/$_AR_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
+        # Memory bumped from the legacy 512Mi to 2Gi because the KB image
+        # loads torch, sentence-transformers, and chromadb at startup; the
+        # legacy non-KB image's 512Mi caused an OOM at first deploy.
         gcloud run services update "$_SERVICE_NAME" \
           --platform=managed \
           --image="$$IMAGE" \
           --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID \
           --region=$_DEPLOY_REGION \
+          --memory=2Gi \
           --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$$TAG" \
           --quiet
 


### PR DESCRIPTION
## Problem

Build `c3368072` completed all four pre-deploy steps (`LoadKBPin`, `PreflightKBAsset`, `Build`, `Push`) successfully on commit `7b30bb4`. The Deploy step failed: the new revision `boomi-mcp-server-00201-pxz` was killed by Cloud Run during startup with

\`\`\`
Memory limit of 512 MiB exceeded with 582 MiB used.
Default STARTUP TCP probe failed 1 time consecutively for container "boomi-mcp-server-1" on port 8080.
\`\`\`

Container logs show all 29 MCP tools registered cleanly; OOM hit right as the KB module began initializing (`torch`, `sentence-transformers` model load, `chromadb` index open). Production traffic stayed on the previous non-KB revision `00200-rt9` (no regression).

The 512Mi limit was sufficient for the non-KB image. The KB stack needs more headroom.

## Fix

Add `--memory=2Gi` to the `gcloud run services update` call in the Deploy step. 2Gi covers:

- ~300 MB base server + Boomi SDK
- ~300-500 MB `torch` + `sentence-transformers` + `all-MiniLM-L6-v2` weights resident
- chromadb sqlite + index resident
- Burst headroom for concurrent requests

Memory only changes for KB-enabled deploys — the value is set as part of the same `update` call that flips `BOOMI_DOCS_ENABLED=true`, so production behavior pre-merge is unaffected.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('cloudbuild.yaml'))"` → OK
- [ ] Merge fires the pipeline. Build steps 1-4 succeed as before; Deploy step now updates the service with `--memory=2Gi`.
- [ ] New revision binds to port 8080 within the startup probe window.
- [ ] `gcloud run services describe boomi-mcp-server --region us-central1` shows `memory: 2Gi` and all three `BOOMI_DOCS_*` env vars.
- [ ] Cloud Run startup log contains `Boomi Docs KB registered: tools search_boomi_docs, read_boomi_doc_page; resource kb://boomi-docs/corpus`.