### PR TITLE
harden oauth refresh path: grace window, default-on diagnostics, storage self-heal, multifernet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,30 @@ GCP_PROJECT_ID=your-gcp-project-id
 
 # For generating a secure JWT secret, run:
 # python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+
+# =============================================================================
+# AUTHENTICATION HARDENING (optional — safe defaults applied)
+# =============================================================================
+# All four have safe defaults. Override only when debugging or rolling out a
+# key rotation. See docs/oauth-migration-runbook.md for the full procedure.
+
+# Refresh-token rotation grace window (seconds). During this window, a
+# just-rotated refresh token still returns the same new tokens it produced
+# on first use — defeats the one-time-use replay race that breaks some
+# OAuth clients. Set to 0 to disable.
+# BOOMI_RT_GRACE_SECONDS=60
+# BOOMI_RT_GRACE_MAX_SIZE=512
+
+# OAuth diagnostic logging is ON by default. Disable to silence the three
+# silent-401 patches in diagnostic_logging.py.
+# BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true
+# Back-compat: BOOMI_OAUTH_DIAGNOSTICS=false also opts out.
+
+# When a stored OAuth client doc fails to decrypt (InvalidToken /
+# ValidationError), delete it so the client can re-register cleanly on
+# its next attempt. Set false to keep the corrupted row for forensics.
+# BOOMI_AUTH_HEAL_CORRUPT_CLIENTS=true
+
+# STORAGE_ENCRYPTION_KEY supports a comma-separated list of Fernet keys
+# (newest first) for zero-downtime rotation via MultiFernet:
+# STORAGE_ENCRYPTION_KEY=<new-key>,<old-key>

--- a/README.md
+++ b/README.md
@@ -234,7 +234,31 @@ OIDC_BASE_URL           # https://boomi.renera.ai
 SESSION_SECRET          # Session signing key for web UI
 MONGODB_URI             # MongoDB Atlas connection string for OAuth state
 JWT_SIGNING_KEY         # Stable key for signing MCP JWT tokens
-STORAGE_ENCRYPTION_KEY  # Fernet key for encrypting OAuth tokens at rest
+STORAGE_ENCRYPTION_KEY  # Fernet key(s) for encrypting OAuth tokens at rest.
+                        # Single value or comma-separated list (newest first)
+                        # to enable zero-downtime key rotation via MultiFernet.
+```
+
+#### Authentication hardening (optional)
+
+All four ship with safe defaults; override only when debugging or
+performing a key rotation. See `docs/oauth-migration-runbook.md` for the
+full rollback procedure.
+
+```bash
+BOOMI_RT_GRACE_SECONDS          # default 60. Window during which a just-
+                                # rotated refresh token still returns the
+                                # same new tokens (defeats one-time-use
+                                # replay race). Set 0 to disable.
+BOOMI_RT_GRACE_MAX_SIZE         # default 512. LRU capacity for the grace cache.
+BOOMI_OAUTH_DIAGNOSTICS_DISABLE # default off (diagnostics ON). Set true to
+                                # silence the three OAuth diagnostic log
+                                # patches. BOOMI_OAUTH_DIAGNOSTICS=false
+                                # also works as a back-compat opt-out.
+BOOMI_AUTH_HEAL_CORRUPT_CLIENTS # default true. When get_client raises
+                                # InvalidToken/ValidationError, delete the
+                                # corrupted MongoDB doc so the client can
+                                # re-register cleanly.
 ```
 
 #### User Credentials Storage

--- a/diagnostic_logging.py
+++ b/diagnostic_logging.py
@@ -1,17 +1,27 @@
 """
-Temporary diagnostic logging for OAuth token refresh debugging.
+OAuth observability patches: log silent 401 paths in the FastMCP auth stack.
 
-Enabled by setting BOOMI_OAUTH_DIAGNOSTICS=true in the environment.
-Patches the upstream FastMCP/MCP SDK to log structured causes when:
-- Client authentication fails on the /token endpoint (the silent 401)
-- Client lookup returns None (storage miss or decryption failure)
-- Fernet decryption fails on stored OAuth data
+These patches are enabled by default in production mode. They emit one
+structured log line per failure at three boundaries that are silent in
+upstream FastMCP/MCP SDK today:
 
-These patches do not change behavior -- they only add logging
-at failure points that are currently silent.
+- Client authentication on the /token endpoint
+  (the silent `unauthorized_client` 401 cause is logged)
+- OAuthProxy.get_client lookup misses
+  (distinguishes storage miss vs decryption/deserialization failure)
+- Encrypted storage GET errors
+  (Fernet InvalidToken, ValidationError, etc.)
 
-Added 2026-04-11 for post-FastMCP-v3-migration cutover observability.
-Remove after the new refresh path is proven stable (~72h post-deploy).
+The patches do not change behavior — they only add logging at failure
+points that would otherwise produce a 401 with no log line.
+
+Disable with BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true. The legacy
+BOOMI_OAUTH_DIAGNOSTICS=false also opts out for backward compatibility.
+
+Originally added 2026-04-11 as a 72-hour post-migration cutover hack;
+promoted to permanent default-on observability on 2026-05-18 because the
+silent 401 paths it monitors are inherent to the upstream design, not a
+transient migration symptom.
 """
 
 import logging

--- a/docs/oauth-migration-runbook.md
+++ b/docs/oauth-migration-runbook.md
@@ -81,29 +81,33 @@ With diagnostics enabled (`BOOMI_OAUTH_DIAGNOSTICS=true`), also check for:
 - `get_client returned None` -- indicates client not found (legacy state)
 - `Token endpoint client auth FAILED` -- shows exact failure reason
 
-## Diagnostic Logging
+## Diagnostic Logging (now default-on)
 
-Temporary observability is available via `BOOMI_OAUTH_DIAGNOSTICS=true`.
+Diagnostic logging at the three silent 401 boundaries (token-endpoint
+client auth, client lookup, encrypted storage GET) is **enabled by
+default** in production mode as of 2026-05-18. No env var is needed.
 
-To enable on Cloud Run:
-
-```bash
-gcloud run services update boomi-mcp-server \
-  --region us-central1 \
-  --project boomimcp \
-  --set-env-vars BOOMI_OAUTH_DIAGNOSTICS=true
-```
-
-To disable after the cutover is stable:
+Disable (operators only — leaves a 401 path silent):
 
 ```bash
 gcloud run services update boomi-mcp-server \
   --region us-central1 \
   --project boomimcp \
-  --remove-env-vars BOOMI_OAUTH_DIAGNOSTICS
+  --set-env-vars BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true
 ```
 
-Plan: Enable for the first 72 hours post-deploy, then disable.
+Re-enable (clear the disable):
+
+```bash
+gcloud run services update boomi-mcp-server \
+  --region us-central1 \
+  --project boomimcp \
+  --remove-env-vars BOOMI_OAUTH_DIAGNOSTICS_DISABLE
+```
+
+The legacy `BOOMI_OAUTH_DIAGNOSTICS=true` continues to be honored as a
+back-compat "on" signal (no-op since the default is already on).
+Setting `BOOMI_OAUTH_DIAGNOSTICS=false` explicitly opts out.
 
 ## MongoDB Diagnostic Script
 
@@ -118,5 +122,42 @@ STORAGE_ENCRYPTION_KEY=$(gcloud secrets versions access 2 --secret=storage-encry
 ## Cleanup (after 2026-04-25)
 
 1. Delete legacy collections from MongoDB Atlas
-2. Remove `BOOMI_OAUTH_DIAGNOSTICS` env var from Cloud Run
-3. Optionally remove `diagnostic_logging.py` and its import in `server.py`
+2. Diagnostic logging is now permanent — do NOT remove
+   `diagnostic_logging.py` or its server.py call site. The silent 401
+   paths it monitors are inherent to the upstream design, not a
+   transient migration symptom.
+
+## Token refresh hardening (2026-05-18)
+
+Four env vars introduced to harden the OAuth refresh path against the
+three root causes of "MCP becomes inaccessible after ~1h without
+session reload" (refresh-token rotation race, silent storage failures,
+encryption-key rotation pain).
+
+All four ship enabled by default with safe values. Override only when
+debugging or rolling out a key rotation.
+
+| Env var | Default | Purpose | Off-switch |
+|---|---|---|---|
+| `BOOMI_RT_GRACE_SECONDS` | `60` | Window during which a just-rotated refresh token still returns the same new tokens it produced on first use (defeats one-time-use replay race in clients). | Set to `0` |
+| `BOOMI_RT_GRACE_MAX_SIZE` | `512` | LRU capacity for the grace-window cache. | — |
+| `BOOMI_OAUTH_DIAGNOSTICS_DISABLE` | unset (= diagnostics ON) | Turn off all OAuth diagnostic logging (the three silent-401 patches in `diagnostic_logging.py`). | Set to `true` |
+| `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS` | `true` | When `get_client` hits `InvalidToken`/`ValidationError`, delete the corrupted MongoDB doc so the client can re-register cleanly. | Set to `false` (still logs ERROR, just leaves the row) |
+
+`STORAGE_ENCRYPTION_KEY` now also accepts a comma-separated list of
+Fernet keys, newest first. Single-value remains backward compatible.
+Multi-value wraps in `MultiFernet` (writes use first; reads accept
+any) so key rotation no longer requires dropping any documents.
+
+Example zero-downtime rotation:
+
+```bash
+# 1. Generate a new key, then set both old+new on the service
+NEW_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+OLD_KEY=$(gcloud secrets versions access latest --secret=storage-encryption-key --project=boomimcp)
+gcloud secrets versions add storage-encryption-key \
+  --data-file=- --project=boomimcp <<< "${NEW_KEY},${OLD_KEY}"
+# 2. Redeploy. Writes now use NEW_KEY, reads accept either.
+# 3. After 30 days (RT expiry window), all docs are re-encrypted.
+# 4. Drop OLD_KEY: re-add the secret as just NEW_KEY.
+```

--- a/docs/oauth-migration-runbook.md
+++ b/docs/oauth-migration-runbook.md
@@ -142,22 +142,55 @@ debugging or rolling out a key rotation.
 | `BOOMI_RT_GRACE_SECONDS` | `60` | Window during which a just-rotated refresh token still returns the same new tokens it produced on first use (defeats one-time-use replay race in clients). | Set to `0` |
 | `BOOMI_RT_GRACE_MAX_SIZE` | `512` | LRU capacity for the grace-window cache. | — |
 | `BOOMI_OAUTH_DIAGNOSTICS_DISABLE` | unset (= diagnostics ON) | Turn off all OAuth diagnostic logging (the three silent-401 patches in `diagnostic_logging.py`). | Set to `true` |
-| `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS` | `true` | When `get_client` hits `InvalidToken`/`ValidationError`, delete the corrupted MongoDB doc so the client can re-register cleanly. | Set to `false` (still logs ERROR, just leaves the row) |
+| `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS` | `true` | When `get_client` hits `DecryptionError`/`DeserializationError` (or the bare `InvalidToken`/`ValidationError` defensive cases), delete the corrupted MongoDB doc so the client can re-register cleanly. | Set to `false` (still logs ERROR, just leaves the row) |
 
 `STORAGE_ENCRYPTION_KEY` now also accepts a comma-separated list of
 Fernet keys, newest first. Single-value remains backward compatible.
-Multi-value wraps in `MultiFernet` (writes use first; reads accept
-any) so key rotation no longer requires dropping any documents.
+Multi-value wraps in `MultiFernet`: reads accept any listed key, writes
+use the first one.
 
-Example zero-downtime rotation:
+### Zero-downtime key rotation procedure
+
+**Important caveat.** `MultiFernet` rewraps on PUT, never on GET. The
+`mcp-upstream-tokens`, `mcp-jti-mappings`, and `mcp-refresh-tokens`
+collections naturally rotate to the new key because token refresh
+rewrites those rows on every refresh cycle. But the
+`mcp-oauth-proxy-clients` collection holds Dynamic Client Registration
+(DCR) documents that are written **once** at registration and never
+naturally rewritten by normal traffic. If you drop OLD_KEY before those
+docs are re-encrypted, every long-lived client will fail decryption on
+its next request and (with `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS=true`)
+have its registration deleted -- forcing every user to re-add the
+connector. To avoid that, run the rewrap helper before dropping the
+old key.
 
 ```bash
-# 1. Generate a new key, then set both old+new on the service
+# 1. Add the new key, leaving the old one in place. Newest first.
 NEW_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 OLD_KEY=$(gcloud secrets versions access latest --secret=storage-encryption-key --project=boomimcp)
 gcloud secrets versions add storage-encryption-key \
   --data-file=- --project=boomimcp <<< "${NEW_KEY},${OLD_KEY}"
-# 2. Redeploy. Writes now use NEW_KEY, reads accept either.
-# 3. After 30 days (RT expiry window), all docs are re-encrypted.
-# 4. Drop OLD_KEY: re-add the secret as just NEW_KEY.
+
+# 2. Redeploy the service. Writes now use NEW_KEY; reads accept either.
+#    Token-store rows re-encrypt naturally as refresh traffic flows.
+
+# 3. Re-encrypt the DCR client docs (they are NOT rewritten by refresh).
+#    Run with the same env vars the server uses:
+MONGODB_URI=$(gcloud secrets versions access latest --secret=mongodb-uri --project=boomimcp) \
+STORAGE_ENCRYPTION_KEY="${NEW_KEY},${OLD_KEY}" \
+.venv/bin/python scripts/rewrap_oauth_clients.py
+# Exit 0 with decrypt_failed=0 is required before step 4.
+# Optionally inspect first with `--dry-run`.
+
+# 4. Optional: wait ~30 days for transient token-store rows to roll over
+#    naturally (the longest TTL in those collections is the upstream
+#    refresh-token expiry). Skip if you trust step 3 + active traffic.
+
+# 5. Drop OLD_KEY: re-add the secret as just NEW_KEY.
+gcloud secrets versions add storage-encryption-key \
+  --data-file=- --project=boomimcp <<< "${NEW_KEY}"
 ```
+
+If step 3 reports `decrypt_failed > 0`, do **not** drop the old key.
+Either restore the missing historical key, or accept that the listed
+clients will need to re-register, then re-run before dropping.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -119,6 +119,13 @@ spec:
               name: boomi-mcp-config
               key: cors_origins
 
+        # OAuth observability (default ON since 2026-05-18; pinned here
+        # so the manifest reflects the intended state and a future
+        # default flip can't silently turn it off). Disable with
+        # BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true instead of removing this.
+        - name: BOOMI_OAUTH_DIAGNOSTICS
+          value: "true"
+
         # Boomi Docs Knowledge Base (optional retrieval layer)
         - name: BOOMI_DOCS_ENABLED
           valueFrom:

--- a/refresh_token_grace_patch.py
+++ b/refresh_token_grace_patch.py
@@ -77,6 +77,17 @@ def apply_refresh_token_grace_patch() -> None:
     max_size = int(os.getenv("BOOMI_RT_GRACE_MAX_SIZE", "512"))
     cache = _TTLCache(max_size=max_size)
 
+    # Per-token singleflight: ensures only one call into the underlying
+    # OAuthProxy.exchange_refresh_token runs for each old refresh-token
+    # hash, even under concurrent (parallel-tab / network-retry) load.
+    # Without this, two concurrent refreshes both observe a cache miss
+    # and both enter the original exchange path; the first deletes the
+    # FastMCP refresh-token row + JTI mapping (proxy.py:1333,1351), the
+    # second then fails with `invalid_grant` "Refresh token mapping not
+    # found" -- the exact 401 this patch advertises that it prevents.
+    inflight: dict[str, asyncio.Future] = {}
+    inflight_lock = asyncio.Lock()
+
     # Imports are deferred so this module can be imported in LOCAL_MODE
     # without pulling in the full FastMCP auth stack.
     from fastmcp.server.auth.oauth_proxy.models import _hash_token
@@ -91,11 +102,25 @@ def apply_refresh_token_grace_patch() -> None:
         if result is not None:
             return result
 
-        # Original lookup missed. Check the grace cache -- the same RT may
-        # have been rotated within the grace window and we still want the
-        # framework to proceed to exchange (which will short-circuit
-        # using the cached OAuthToken).
-        cached = await cache.get(_hash_token(refresh_token))
+        # Original lookup missed. There are two ways this can happen
+        # within the grace window:
+        #   (a) The exchange has already completed and the cache holds the
+        #       rotated tokens -- check cache and synthesize.
+        #   (b) A concurrent exchange is in flight and has already deleted
+        #       the storage row but hasn't populated the cache yet -- wait
+        #       on the in-flight Future, then re-check the cache.
+        old_hash = _hash_token(refresh_token)
+
+        async with inflight_lock:
+            future = inflight.get(old_hash)
+        if future is not None:
+            try:
+                await future  # Wait for the leader to finish.
+            except Exception:
+                # Leader failed; let the cache miss decide below.
+                pass
+
+        cached = await cache.get(old_hash)
         if cached is None:
             return None
 
@@ -124,33 +149,67 @@ def apply_refresh_token_grace_patch() -> None:
 
     async def patched_exchange_refresh_token(self, client, refresh_token, scopes):
         old_hash = _hash_token(refresh_token.token)
+        client_id_repr = (client.client_id or "<none>")[:8]
 
+        # Fast path: someone has already rotated this RT within the grace
+        # window. Skip both the singleflight and the upstream call.
         cached = await cache.get(old_hash)
         if cached is not None:
             oauth_token, _cached_client_id, _cached_scopes = cached
-            client_id_repr = (client.client_id or "<none>")[:8]
             logger.info(
                 "Refresh-token grace cache HIT (client=%s) -- returning cached rotated tokens",
                 client_id_repr,
             )
             return oauth_token
 
-        result = await orig_exchange_refresh_token(self, client, refresh_token, scopes)
-        # Store before returning so a concurrent retry on the same RT
-        # sees the same new tokens. The original has already deleted the
-        # old RT row and JTI; the grace cache fills the gap for
-        # `grace_seconds`.
+        # Singleflight: claim the slot or piggyback on the in-flight leader.
+        is_leader = False
+        async with inflight_lock:
+            # Re-check the cache under the lock to close the obvious
+            # check-then-act race against a leader that just finished.
+            cached = await cache.get(old_hash)
+            if cached is not None:
+                return cached[0]
+            future = inflight.get(old_hash)
+            if future is None:
+                future = asyncio.get_event_loop().create_future()
+                inflight[old_hash] = future
+                is_leader = True
+
+        if not is_leader:
+            logger.info(
+                "Refresh-token grace singleflight WAIT (client=%s) -- joining in-flight rotation",
+                client_id_repr,
+            )
+            # Re-raise the leader's exception so the framework returns the
+            # same TokenError to all racing callers.
+            return await future
+
+        # Leader path: run the real exchange, populate the cache, and
+        # release the singleflight slot regardless of outcome.
+        try:
+            result = await orig_exchange_refresh_token(self, client, refresh_token, scopes)
+        except BaseException as exc:
+            async with inflight_lock:
+                inflight.pop(old_hash, None)
+            if not future.done():
+                future.set_exception(exc)
+            raise
         await cache.set(
             old_hash,
             (result, client.client_id, list(scopes)),
             time.time() + grace_seconds,
         )
+        async with inflight_lock:
+            inflight.pop(old_hash, None)
+        if not future.done():
+            future.set_result(result)
         return result
 
     OAuthProxy.load_refresh_token = patched_load_refresh_token
     OAuthProxy.exchange_refresh_token = patched_exchange_refresh_token
     logger.info(
-        "Refresh-token grace window ENABLED (%ds, max_size=%d)",
+        "Refresh-token grace window ENABLED (%ds, max_size=%d, singleflight=on)",
         grace_seconds,
         max_size,
     )

--- a/refresh_token_grace_patch.py
+++ b/refresh_token_grace_patch.py
@@ -1,0 +1,156 @@
+"""
+Refresh-token rotation grace window (Fix A of the OAuth hardening plan).
+
+Upstream FastMCP v3.1.1 enforces one-time-use refresh tokens: each
+successful exchange deletes the old refresh-token row and JTI mapping
+(see fastmcp/server/auth/oauth_proxy/proxy.py around lines 1333 and
+1351). Any client retry-after-blip, parallel-tab refresh, or persistence
+hiccup that presents the old refresh token a second time returns
+`Refresh token mapping not found` -> 401 invalid_grant -> the user must
+fully re-authenticate.
+
+This patch keeps the old refresh token usable for a short grace window
+(default 60s) by returning the *same* new tokens that the first exchange
+produced. Same pattern used by Auth0 ("absolute refresh-token reuse
+interval") and AWS Cognito ("reuse grace"). Google's own refresh token
+is still rotated only when Google rotates it -- this patch only covers
+the FastMCP-side rotation.
+
+Disable with `BOOMI_RT_GRACE_SECONDS=0`. Capacity bounded by
+`BOOMI_RT_GRACE_MAX_SIZE` (default 512).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections import OrderedDict
+from typing import Any
+
+logger = logging.getLogger("boomi.refresh_token_grace")
+
+
+class _TTLCache:
+    """Bounded LRU dict with per-entry expiry. Single asyncio.Lock; O(1)."""
+
+    def __init__(self, max_size: int) -> None:
+        self._data: "OrderedDict[str, tuple[float, Any]]" = OrderedDict()
+        self._max_size = max_size
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> Any | None:
+        async with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return None
+            expires_at, value = entry
+            if expires_at <= time.time():
+                self._data.pop(key, None)
+                return None
+            self._data.move_to_end(key)
+            return value
+
+    async def set(self, key: str, value: Any, expires_at: float) -> None:
+        async with self._lock:
+            self._data[key] = (expires_at, value)
+            self._data.move_to_end(key)
+            while len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+
+
+def apply_refresh_token_grace_patch() -> None:
+    """Install the grace-window monkey-patches on OAuthProxy.
+
+    Idempotent at import time: applies once per Python process. Calling
+    twice is harmless because the second call overwrites the same two
+    methods with functionally identical wrappers (the inner cache is
+    re-created, which is acceptable -- there are no live tokens at
+    server startup).
+    """
+    grace_seconds = int(os.getenv("BOOMI_RT_GRACE_SECONDS", "60"))
+    if grace_seconds <= 0:
+        logger.info("Refresh-token grace window DISABLED (BOOMI_RT_GRACE_SECONDS=0)")
+        return
+
+    max_size = int(os.getenv("BOOMI_RT_GRACE_MAX_SIZE", "512"))
+    cache = _TTLCache(max_size=max_size)
+
+    # Imports are deferred so this module can be imported in LOCAL_MODE
+    # without pulling in the full FastMCP auth stack.
+    from fastmcp.server.auth.oauth_proxy.models import _hash_token
+    from fastmcp.server.auth.oauth_proxy.proxy import OAuthProxy
+    from mcp.server.auth.provider import RefreshToken
+
+    orig_load_refresh_token = OAuthProxy.load_refresh_token
+    orig_exchange_refresh_token = OAuthProxy.exchange_refresh_token
+
+    async def patched_load_refresh_token(self, client, refresh_token):
+        result = await orig_load_refresh_token(self, client, refresh_token)
+        if result is not None:
+            return result
+
+        # Original lookup missed. Check the grace cache -- the same RT may
+        # have been rotated within the grace window and we still want the
+        # framework to proceed to exchange (which will short-circuit
+        # using the cached OAuthToken).
+        cached = await cache.get(_hash_token(refresh_token))
+        if cached is None:
+            return None
+
+        oauth_token, cached_client_id, cached_scopes = cached
+        # Cross-client reuse defense: only honor the grace entry for the
+        # original client_id.
+        if cached_client_id != client.client_id:
+            logger.warning(
+                "Refresh-token grace cache client_id mismatch: expected %s, got %s",
+                cached_client_id,
+                client.client_id,
+            )
+            return None
+
+        # expires_at on RefreshToken is the upstream RT expiry; we don't
+        # know the exact value here, so use the OAuthToken.expires_in as a
+        # lower-bound proxy. The framework only uses expires_at for the
+        # not-expired check, which we want to pass.
+        expires_at = int(time.time() + (oauth_token.expires_in or 3600))
+        return RefreshToken(
+            token=refresh_token,
+            client_id=cached_client_id,
+            scopes=cached_scopes,
+            expires_at=expires_at,
+        )
+
+    async def patched_exchange_refresh_token(self, client, refresh_token, scopes):
+        old_hash = _hash_token(refresh_token.token)
+
+        cached = await cache.get(old_hash)
+        if cached is not None:
+            oauth_token, _cached_client_id, _cached_scopes = cached
+            client_id_repr = (client.client_id or "<none>")[:8]
+            logger.info(
+                "Refresh-token grace cache HIT (client=%s) -- returning cached rotated tokens",
+                client_id_repr,
+            )
+            return oauth_token
+
+        result = await orig_exchange_refresh_token(self, client, refresh_token, scopes)
+        # Store before returning so a concurrent retry on the same RT
+        # sees the same new tokens. The original has already deleted the
+        # old RT row and JTI; the grace cache fills the gap for
+        # `grace_seconds`.
+        await cache.set(
+            old_hash,
+            (result, client.client_id, list(scopes)),
+            time.time() + grace_seconds,
+        )
+        return result
+
+    OAuthProxy.load_refresh_token = patched_load_refresh_token
+    OAuthProxy.exchange_refresh_token = patched_exchange_refresh_token
+    logger.info(
+        "Refresh-token grace window ENABLED (%ds, max_size=%d)",
+        grace_seconds,
+        max_size,
+    )

--- a/scripts/rewrap_oauth_clients.py
+++ b/scripts/rewrap_oauth_clients.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Re-encrypt all OAuth client documents under the newest STORAGE_ENCRYPTION_KEY.
+
+Why this exists:
+    MultiFernet (used by Fix C.3 of the OAuth hardening plan) decrypts under
+    any listed key but only re-encrypts on PUT. The `mcp-oauth-proxy-clients`
+    collection holds long-lived Dynamic Client Registration (DCR) documents
+    that are written exactly once at registration and never naturally
+    rewritten by token refresh, runtime CIMD lookup notwithstanding.
+
+    Without this script, dropping OLD_KEY from STORAGE_ENCRYPTION_KEY after
+    the documented 30-day wait will still 401 any DCR client whose
+    registration document was written before the rotation -- with Fix C.2
+    enabled, the corrupted doc gets self-healed (deleted) and the user is
+    forced into Dynamic Client Registration again.
+
+What it does:
+    For every document in `mcp-oauth-proxy-clients`:
+      1. GET via FernetEncryptionWrapper backed by MultiFernet (succeeds
+         under either the new or the old key).
+      2. PUT via the same wrapper (forces re-encryption under the first
+         key in the list = the newest key).
+    Reports counts: total / re-wrapped / decrypt_failed / unchanged.
+
+When to run:
+    Run after rotating STORAGE_ENCRYPTION_KEY to the comma-separated
+    "NEW,OLD" form and BEFORE dropping OLD. See
+    docs/oauth-migration-runbook.md "Token refresh hardening" section.
+
+Usage (from project root with MONGODB_URI and STORAGE_ENCRYPTION_KEY set
+either in .env or in the environment directly):
+    .venv/bin/python scripts/rewrap_oauth_clients.py [--dry-run] [--collection <name>]
+
+Exit code is 0 on a clean rewrap, 1 on partial failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ENV = _REPO_ROOT / ".env"
+if _ENV.exists():
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(_ENV)
+    except ImportError:
+        pass
+
+DB_NAME = "boomi_mcp"
+DEFAULT_COLLECTION = "mcp-oauth-proxy-clients"
+
+
+def _build_fernet(storage_encryption_key: str):
+    """Mirrors the parsing logic in server.py."""
+    from cryptography.fernet import Fernet, MultiFernet
+
+    keys = [k.strip() for k in storage_encryption_key.split(",") if k.strip()]
+    if not keys:
+        raise SystemExit("STORAGE_ENCRYPTION_KEY must contain at least one Fernet key")
+    fernets = [Fernet(k.encode()) for k in keys]
+    return fernets[0] if len(fernets) == 1 else MultiFernet(fernets), len(fernets)
+
+
+async def _enumerate_keys(mongodb_uri: str, collection: str) -> list[str]:
+    """Return all document keys in the given collection."""
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    client = AsyncIOMotorClient(mongodb_uri)
+    try:
+        db = client[DB_NAME]
+        cursor = db[collection].find({}, projection={"key": 1, "_id": 0})
+        keys = []
+        async for doc in cursor:
+            key = doc.get("key")
+            if key:
+                keys.append(key)
+        return keys
+    finally:
+        client.close()
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("--dry-run", action="store_true", help="Read each doc but do not write back")
+    parser.add_argument("--collection", default=DEFAULT_COLLECTION,
+                        help=f"Collection to rewrap (default: {DEFAULT_COLLECTION})")
+    args = parser.parse_args()
+
+    mongodb_uri = os.getenv("MONGODB_URI")
+    storage_encryption_key = os.getenv("STORAGE_ENCRYPTION_KEY")
+    if not mongodb_uri:
+        print("ERROR: MONGODB_URI not set", file=sys.stderr)
+        return 1
+    if not storage_encryption_key:
+        print("ERROR: STORAGE_ENCRYPTION_KEY not set", file=sys.stderr)
+        return 1
+
+    fernet, key_count = _build_fernet(storage_encryption_key)
+    print(f"Loaded {key_count} Fernet key(s); writes will use the newest key.")
+    if key_count == 1:
+        print("WARNING: only one key configured. Rewrap is a no-op (same key in/out).")
+
+    keys = await _enumerate_keys(mongodb_uri, args.collection)
+    print(f"Found {len(keys)} document(s) in {args.collection}")
+    if not keys:
+        return 0
+
+    from key_value.aio.stores.mongodb import MongoDBStore
+    from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+    store = MongoDBStore(url=mongodb_uri, db_name=DB_NAME, coll_name=args.collection)
+    wrapped = FernetEncryptionWrapper(key_value=store, fernet=fernet)
+
+    total = len(keys)
+    rewrapped = 0
+    decrypt_failed: list[str] = []
+    other_failed: list[tuple[str, str]] = []
+
+    for key in keys:
+        try:
+            value = await wrapped.get(key=key)
+        except Exception as exc:  # DecryptionError, DeserializationError, etc.
+            decrypt_failed.append(key)
+            print(f"  [FAIL decrypt] key={key[:16]}... {type(exc).__name__}: {exc}")
+            continue
+        if value is None:
+            # The wrapper returned None (e.g. doc was deleted between
+            # enumerate and read). Skip silently.
+            continue
+        if args.dry_run:
+            rewrapped += 1
+            continue
+        try:
+            await wrapped.put(key=key, value=value)
+            rewrapped += 1
+        except Exception as exc:
+            other_failed.append((key, f"{type(exc).__name__}: {exc}"))
+            print(f"  [FAIL write]   key={key[:16]}... {type(exc).__name__}: {exc}")
+
+    action = "would re-encrypt" if args.dry_run else "re-encrypted"
+    print()
+    print(f"Summary: total={total} {action}={rewrapped} "
+          f"decrypt_failed={len(decrypt_failed)} other_failed={len(other_failed)}")
+    if decrypt_failed:
+        print("Keys that failed to decrypt under ANY listed key:")
+        for k in decrypt_failed:
+            print(f"  {k}")
+        print("These are unrecoverable. Either restore the missing historical key "
+              "and re-run, or delete the docs (the clients will re-register on next DCR).")
+
+    return 0 if not decrypt_failed and not other_failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/server.py
+++ b/server.py
@@ -450,12 +450,17 @@ if not LOCAL_MODE:
         print(f"       - OIDC_BASE_URL")
         sys.exit(1)
 
-    # Temporary diagnostic logging for post-migration OAuth cutover.
-    # Enable with BOOMI_OAUTH_DIAGNOSTICS=true; remove after refresh path is stable.
-    if os.getenv("BOOMI_OAUTH_DIAGNOSTICS", "").lower() in ("true", "1", "yes"):
+    # OAuth observability: log silent 401 paths in the FastMCP auth stack.
+    # Default ON; disable with BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true, or
+    # explicitly opt out via BOOMI_OAUTH_DIAGNOSTICS=false (back-compat).
+    _diag_disable = os.getenv("BOOMI_OAUTH_DIAGNOSTICS_DISABLE", "").lower() in ("true", "1", "yes")
+    _diag_legacy_opt_in = os.getenv("BOOMI_OAUTH_DIAGNOSTICS", "true").lower() in ("true", "1", "yes")
+    if not _diag_disable and _diag_legacy_opt_in:
         from diagnostic_logging import apply_all_patches
         apply_all_patches(auth_provider=auth, encrypted_storage=encrypted_storage)
         print("[INFO] OAuth diagnostic logging ENABLED")
+    else:
+        print("[INFO] OAuth diagnostic logging DISABLED")
 
     # Create FastMCP server with auth
     mcp = FastMCP(

--- a/server.py
+++ b/server.py
@@ -464,6 +464,12 @@ if not LOCAL_MODE:
     else:
         print("[INFO] OAuth diagnostic logging DISABLED")
 
+    # Storage self-healing: evict corrupted client documents on decryption
+    # failure so a stale or bad-key row doesn't permanently 401 a client.
+    # Applied AFTER diagnostic logging so the inner logger fires first.
+    from storage_healing_patch import apply_storage_healing_patch
+    apply_storage_healing_patch(auth_provider=auth)
+
     # Create FastMCP server with auth
     mcp = FastMCP(
         name="Boomi MCP Server",

--- a/server.py
+++ b/server.py
@@ -378,7 +378,7 @@ if not LOCAL_MODE:
     from fastmcp.server.auth.providers.google import GoogleProvider
     from key_value.aio.stores.mongodb import MongoDBStore
     from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
-    from cryptography.fernet import Fernet
+    from cryptography.fernet import Fernet, MultiFernet
     from verified_storage import VerifiedStorage
     from consent_csp_patch import apply_consent_csp_patch
     from loopback_redirect_patch import apply_loopback_redirect_patch
@@ -417,10 +417,35 @@ if not LOCAL_MODE:
             coll_name="oauth_tokens"
         )
 
+        # Parse STORAGE_ENCRYPTION_KEY as a comma-separated list. Single
+        # value -> Fernet (unchanged). Multiple values -> MultiFernet, which
+        # accepts decryption under any listed key and writes under the
+        # first one. This enables zero-downtime key rotation.
+        _key_list = [
+            k.strip() for k in storage_encryption_key.split(",") if k.strip()
+        ]
+        if not _key_list:
+            raise ValueError(
+                "STORAGE_ENCRYPTION_KEY must contain at least one Fernet key"
+            )
+        try:
+            _fernets = [Fernet(k.encode()) for k in _key_list]
+        except Exception as exc:
+            raise ValueError(
+                "STORAGE_ENCRYPTION_KEY contains an invalid Fernet key "
+                "(comma-separated list expected, newest first): " + str(exc)
+            ) from exc
+        _fernet = _fernets[0] if len(_fernets) == 1 else MultiFernet(_fernets)
+        if len(_fernets) > 1:
+            print(
+                f"[INFO] STORAGE_ENCRYPTION_KEY rotation: {len(_fernets)} keys "
+                "loaded (writes use newest, reads accept any)"
+            )
+
         encrypted_storage = VerifiedStorage(
             FernetEncryptionWrapper(
                 key_value=mongodb_storage,
-                fernet=Fernet(storage_encryption_key.encode())
+                fernet=_fernet
             )
         )
 

--- a/server.py
+++ b/server.py
@@ -382,9 +382,11 @@ if not LOCAL_MODE:
     from verified_storage import VerifiedStorage
     from consent_csp_patch import apply_consent_csp_patch
     from loopback_redirect_patch import apply_loopback_redirect_patch
+    from refresh_token_grace_patch import apply_refresh_token_grace_patch
 
     apply_consent_csp_patch()
     apply_loopback_redirect_patch()
+    apply_refresh_token_grace_patch()
 
     # Create Google OAuth provider
     try:

--- a/storage_healing_patch.py
+++ b/storage_healing_patch.py
@@ -1,0 +1,105 @@
+"""
+Storage self-healing for corrupted OAuth client documents (Fix C.2).
+
+Today the chain is:
+
+    ClientAuthenticator.authenticate_request
+      -> OAuthProxy.get_client
+        -> PydanticAdapter.get
+          -> VerifiedStorage.get (passthrough)
+            -> FernetEncryptionWrapper.get  (raises InvalidToken on bad ciphertext)
+              -> MongoDBStore.get
+
+When the ciphertext for a `mcp-oauth-proxy-clients` document can no longer
+be decrypted (encryption key rotation that lost the old key, corrupted
+write, or a mixed-vintage row from the April-11 migration), the exception
+bubbles up to ClientAuthenticator and turns into a permanent 401 for the
+affected client_id. The client cannot recover without a manual operator
+delete.
+
+This patch wraps `auth_provider.get_client` (after diagnostic_logging has
+already wrapped it for ERROR logging) and on `InvalidToken` /
+`pydantic.ValidationError`:
+
+  1. Logs an ERROR with the truncated client_id + exception class.
+  2. Calls `_client_store.delete(key=client_id)` to evict the corrupted
+     document — single targeted call, no scans.
+  3. Returns None, which surfaces to the SDK as the existing 401
+     `unauthorized_client`. The client falls into Dynamic Client
+     Registration on its next attempt and gets a fresh, properly-
+     encrypted entry.
+
+Disable with `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS=false`. When disabled,
+the ERROR log still fires but the corrupted document is left in place
+for forensic inspection; the wrapper still returns None so the user
+sees the same 401, just without the self-heal step.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import types
+
+logger = logging.getLogger("boomi.storage_healing")
+
+CORRUPT_CLIENT_COLLECTION = "mcp-oauth-proxy-clients"
+
+
+def apply_storage_healing_patch(auth_provider) -> None:
+    """Wrap auth_provider.get_client to self-heal corrupted client docs.
+
+    Call this AFTER `diagnostic_logging.apply_all_patches(...)` so that
+    the diagnostic logging wrapper sits inside the healing wrapper:
+    the inner wrapper's ERROR log still fires before this outer wrapper
+    catches the exception.
+    """
+    heal_enabled = os.getenv(
+        "BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true"
+    ).lower() in ("true", "1", "yes")
+
+    # Imports deferred so this module can be imported in LOCAL_MODE without
+    # pulling in cryptography/pydantic.
+    from cryptography.fernet import InvalidToken
+    from pydantic import ValidationError
+
+    original_get_client = auth_provider.get_client
+
+    async def patched_get_client(self, client_id):
+        try:
+            return await original_get_client(client_id)
+        except (InvalidToken, ValidationError) as exc:
+            client_id_repr = (
+                client_id[:16] + "..."
+                if client_id and len(client_id) > 16
+                else client_id
+            )
+            logger.error(
+                "Corrupted oauth client document detected: client_id=%s "
+                "collection=%s error=%s: %s",
+                client_id_repr,
+                CORRUPT_CLIENT_COLLECTION,
+                type(exc).__name__,
+                exc,
+            )
+            if heal_enabled:
+                try:
+                    await self._client_store.delete(key=client_id)
+                    logger.error(
+                        "Deleted corrupted client document client_id=%s "
+                        "(client will be re-registered on next DCR attempt)",
+                        client_id_repr,
+                    )
+                except Exception as delete_exc:  # pragma: no cover - defensive
+                    logger.error(
+                        "Failed to delete corrupted client_id=%s: %s: %s",
+                        client_id_repr,
+                        type(delete_exc).__name__,
+                        delete_exc,
+                    )
+            return None
+
+    auth_provider.get_client = types.MethodType(patched_get_client, auth_provider)
+    logger.info(
+        "Storage self-healing ENABLED (heal_on_corrupt=%s)", heal_enabled
+    )

--- a/storage_healing_patch.py
+++ b/storage_healing_patch.py
@@ -59,16 +59,29 @@ def apply_storage_healing_patch(auth_provider) -> None:
     ).lower() in ("true", "1", "yes")
 
     # Imports deferred so this module can be imported in LOCAL_MODE without
-    # pulling in cryptography/pydantic.
+    # pulling in cryptography/pydantic/key_value.
+    #
+    # What the storage stack actually raises (verified against
+    # py-key-value-aio==0.4.4 + pydantic==2.12.3):
+    #   - FernetEncryptionWrapper.get() wraps cryptography.InvalidToken as
+    #     key_value.aio.errors.DecryptionError before it ever reaches us.
+    #   - PydanticAdapter.get() with raise_on_validation_error=True (the
+    #     setting OAuthProxy uses for _client_store at proxy.py:476) wraps
+    #     pydantic.ValidationError as key_value.aio.errors.DeserializationError.
+    # The bare cryptography/pydantic exceptions are kept as defense-in-depth
+    # in case a future upstream change short-circuits the wrappers.
     from cryptography.fernet import InvalidToken
+    from key_value.aio.errors import DecryptionError, DeserializationError
     from pydantic import ValidationError
+
+    _heal_triggers = (DecryptionError, DeserializationError, InvalidToken, ValidationError)
 
     original_get_client = auth_provider.get_client
 
     async def patched_get_client(self, client_id):
         try:
             return await original_get_client(client_id)
-        except (InvalidToken, ValidationError) as exc:
+        except _heal_triggers as exc:
             client_id_repr = (
                 client_id[:16] + "..."
                 if client_id and len(client_id) > 16

--- a/tests/test_multifernet_rotation.py
+++ b/tests/test_multifernet_rotation.py
@@ -1,0 +1,119 @@
+"""Tests for the STORAGE_ENCRYPTION_KEY MultiFernet rotation logic (Fix C.3).
+
+These tests exercise the standalone behavior of MultiFernet (no server
+boot required) and the parsing helper in server.py is exercised via an
+isolated import of the parsing block.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+
+
+def _gen_key() -> str:
+    return Fernet.generate_key().decode()
+
+
+# --- MultiFernet round-trips (covers Fix C.3's core invariant) ---
+
+
+def test_multifernet_decrypts_old_key_ciphertext():
+    """Ciphertext encrypted with key A is readable by MultiFernet([B, A])."""
+    key_a = _gen_key()
+    key_b = _gen_key()
+
+    ct_under_a = Fernet(key_a.encode()).encrypt(b"hello")
+    mf = MultiFernet([Fernet(key_b.encode()), Fernet(key_a.encode())])
+    assert mf.decrypt(ct_under_a) == b"hello"
+
+
+def test_multifernet_writes_use_first_key():
+    """MultiFernet([B, A]) writes ciphertext that ONLY B can decrypt."""
+    key_a = _gen_key()
+    key_b = _gen_key()
+
+    mf = MultiFernet([Fernet(key_b.encode()), Fernet(key_a.encode())])
+    ct = mf.encrypt(b"hello")
+
+    assert Fernet(key_b.encode()).decrypt(ct) == b"hello"
+    with pytest.raises(InvalidToken):
+        Fernet(key_a.encode()).decrypt(ct)
+
+
+def test_multifernet_rejects_unknown_key():
+    """A ciphertext encrypted with a key NOT in the list raises InvalidToken."""
+    key_a = _gen_key()
+    key_b = _gen_key()
+    key_other = _gen_key()
+
+    ct_under_other = Fernet(key_other.encode()).encrypt(b"hi")
+    mf = MultiFernet([Fernet(key_b.encode()), Fernet(key_a.encode())])
+    with pytest.raises(InvalidToken):
+        mf.decrypt(ct_under_other)
+
+
+# --- Parsing helper logic mirrored from server.py block ---
+
+
+def _parse_storage_keys(storage_encryption_key: str):
+    """Mirrors the parsing block in server.py for unit testing.
+
+    Kept in sync manually with server.py — if you change the parsing
+    there, update this and the tests below.
+    """
+    key_list = [k.strip() for k in storage_encryption_key.split(",") if k.strip()]
+    if not key_list:
+        raise ValueError(
+            "STORAGE_ENCRYPTION_KEY must contain at least one Fernet key"
+        )
+    try:
+        fernets = [Fernet(k.encode()) for k in key_list]
+    except Exception as exc:
+        raise ValueError(
+            "STORAGE_ENCRYPTION_KEY contains an invalid Fernet key "
+            "(comma-separated list expected, newest first): " + str(exc)
+        ) from exc
+    return fernets[0] if len(fernets) == 1 else MultiFernet(fernets)
+
+
+def test_parse_single_key_returns_plain_fernet():
+    key = _gen_key()
+    out = _parse_storage_keys(key)
+    assert isinstance(out, Fernet)
+    # Round-trip works
+    assert out.decrypt(out.encrypt(b"x")) == b"x"
+
+
+def test_parse_multi_key_returns_multifernet():
+    key_a = _gen_key()
+    key_b = _gen_key()
+    out = _parse_storage_keys(f"{key_b},{key_a}")
+    assert isinstance(out, MultiFernet)
+
+    # And the old-key ciphertext continues to work
+    ct = Fernet(key_a.encode()).encrypt(b"legacy")
+    assert out.decrypt(ct) == b"legacy"
+
+
+def test_parse_handles_whitespace_around_commas():
+    key_a = _gen_key()
+    key_b = _gen_key()
+    out = _parse_storage_keys(f"  {key_b}  ,  {key_a}  ")
+    assert isinstance(out, MultiFernet)
+
+
+def test_parse_rejects_empty_string():
+    with pytest.raises(ValueError, match="at least one Fernet key"):
+        _parse_storage_keys("")
+
+
+def test_parse_rejects_only_commas():
+    with pytest.raises(ValueError, match="at least one Fernet key"):
+        _parse_storage_keys(",,,")
+
+
+def test_parse_rejects_invalid_key_in_list():
+    key_a = _gen_key()
+    with pytest.raises(ValueError, match="invalid Fernet key"):
+        _parse_storage_keys(f"{key_a},this-is-not-a-valid-fernet-key")

--- a/tests/test_refresh_token_grace_patch.py
+++ b/tests/test_refresh_token_grace_patch.py
@@ -212,6 +212,124 @@ def test_load_refresh_token_passes_through_when_original_returns(monkeypatch, re
     assert out is sentinel
 
 
+def test_singleflight_coalesces_concurrent_exchanges(monkeypatch, restore_oauth_proxy):
+    """Two concurrent exchanges on the same RT must hit orig exactly once.
+
+    Reproduces the parallel-tab race that Codex flagged: without
+    singleflight, both coroutines observe a cache MISS and both enter
+    orig_exchange. The first call mutates the upstream FastMCP state
+    (deletes _refresh_token_store row + JTI mapping), and the second
+    would fail with `invalid_grant`. Singleflight ensures the second
+    awaits the first's Future and returns the same OAuthToken.
+    """
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+
+    call_count = {"n": 0}
+    from mcp.shared.auth import OAuthToken
+
+    async def slow_exchange(self, client, refresh_token, scopes):
+        # Sleep long enough that a second coroutine can definitely enter
+        # patched_exchange while we're still in flight here.
+        call_count["n"] += 1
+        my_n = call_count["n"]
+        await asyncio.sleep(0.2)
+        return OAuthToken(
+            access_token=f"AT-{my_n}",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token=f"RT-{my_n}",
+            scope=" ".join(scopes),
+        )
+
+    OAuthProxy.exchange_refresh_token = slow_exchange
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+
+    async def _race():
+        return await asyncio.gather(
+            OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]),
+            OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]),
+            OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]),
+        )
+
+    a, b, c = _run(_race())
+
+    assert call_count["n"] == 1, "underlying exchange must run exactly once under concurrency"
+    assert a.access_token == b.access_token == c.access_token == "AT-1"
+    assert a.refresh_token == b.refresh_token == c.refresh_token == "RT-1"
+
+
+def test_singleflight_propagates_leader_exception(monkeypatch, restore_oauth_proxy):
+    """If the leader's orig_exchange raises, followers must see the same error."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+
+    call_count = {"n": 0}
+
+    async def slow_failing_exchange(self, client, refresh_token, scopes):
+        call_count["n"] += 1
+        await asyncio.sleep(0.1)
+        raise RuntimeError("upstream blew up")
+
+    OAuthProxy.exchange_refresh_token = slow_failing_exchange
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+
+    async def _race():
+        return await asyncio.gather(
+            OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]),
+            OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]),
+            return_exceptions=True,
+        )
+
+    a, b = _run(_race())
+
+    assert call_count["n"] == 1, "underlying exchange must run only once even on failure"
+    assert isinstance(a, RuntimeError) and "upstream blew up" in str(a)
+    assert isinstance(b, RuntimeError) and "upstream blew up" in str(b)
+
+
+def test_singleflight_releases_slot_after_completion(monkeypatch, restore_oauth_proxy):
+    """After leader finishes, a fresh request (cache evicted) must run orig again."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "1")  # short window
+    OAuthProxy = restore_oauth_proxy
+
+    call_count = {"n": 0}
+    from mcp.shared.auth import OAuthToken
+
+    async def quick_exchange(self, client, refresh_token, scopes):
+        call_count["n"] += 1
+        return OAuthToken(access_token=f"AT-{call_count['n']}", token_type="Bearer", expires_in=3600)
+
+    OAuthProxy.exchange_refresh_token = quick_exchange
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+
+    async def _scenario():
+        await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["s"])  # n=1, populates cache
+        await asyncio.sleep(1.2)  # cache expires
+        await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["s"])  # n=2, slot must be free
+
+    _run(_scenario())
+    assert call_count["n"] == 2
+
+
 def test_grace_cache_rejects_cross_client_replay(monkeypatch, restore_oauth_proxy):
     """A cached entry must only be honored for the original client_id."""
     monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")

--- a/tests/test_refresh_token_grace_patch.py
+++ b/tests/test_refresh_token_grace_patch.py
@@ -1,0 +1,244 @@
+"""Tests for the refresh-token rotation grace window patch (Fix A)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------- _TTLCache primitive ----------
+
+def _fresh_module():
+    """Drop any cached import and return a fresh refresh_token_grace_patch."""
+    sys.modules.pop("refresh_token_grace_patch", None)
+    return importlib.import_module("refresh_token_grace_patch")
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_ttlcache_hit_and_miss():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=4)
+    _run(cache.set("k1", "v1", time.time() + 60))
+    assert _run(cache.get("k1")) == "v1"
+    assert _run(cache.get("missing")) is None
+
+
+def test_ttlcache_expiry_evicts():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=4)
+    _run(cache.set("k1", "v1", time.time() - 1))  # already past expiry
+    assert _run(cache.get("k1")) is None
+    # And expired entries are purged on access so the dict shrinks
+    assert "k1" not in cache._data
+
+
+def test_ttlcache_lru_evicts_at_capacity():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=2)
+    far_future = time.time() + 60
+    _run(cache.set("k1", "v1", far_future))
+    _run(cache.set("k2", "v2", far_future))
+    # touch k1 so it moves to MRU
+    assert _run(cache.get("k1")) == "v1"
+    _run(cache.set("k3", "v3", far_future))
+    # k2 is LRU and must be evicted, k1 stays
+    assert _run(cache.get("k2")) is None
+    assert _run(cache.get("k1")) == "v1"
+    assert _run(cache.get("k3")) == "v3"
+
+
+# ---------- apply_refresh_token_grace_patch() ----------
+
+@pytest.fixture
+def restore_oauth_proxy():
+    """Snapshot OAuthProxy methods, yield, then restore. Always runs."""
+    from fastmcp.server.auth.oauth_proxy.proxy import OAuthProxy
+    saved_load = OAuthProxy.load_refresh_token
+    saved_exchange = OAuthProxy.exchange_refresh_token
+    yield OAuthProxy
+    OAuthProxy.load_refresh_token = saved_load
+    OAuthProxy.exchange_refresh_token = saved_exchange
+
+
+def test_disabled_when_grace_seconds_zero(monkeypatch, restore_oauth_proxy):
+    """BOOMI_RT_GRACE_SECONDS=0 short-circuits without monkey-patching."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "0")
+    OAuthProxy = restore_oauth_proxy
+    pre_load = OAuthProxy.load_refresh_token
+    pre_exchange = OAuthProxy.exchange_refresh_token
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    assert OAuthProxy.load_refresh_token is pre_load
+    assert OAuthProxy.exchange_refresh_token is pre_exchange
+
+
+def test_exchange_caches_and_short_circuits_on_replay(monkeypatch, restore_oauth_proxy):
+    """Same RT presented twice within the window returns the cached OAuthToken."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+
+    call_count = {"n": 0}
+
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        call_count["n"] += 1
+        return OAuthToken(
+            access_token=f"AT-{call_count['n']}",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token=f"RT-{call_count['n']}",
+            scope=" ".join(scopes),
+        )
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()  # `self` placeholder
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-original")
+    scopes = ["openid"]
+
+    first = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, scopes))
+    second = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, scopes))
+
+    assert call_count["n"] == 1, "underlying exchange must be called only once"
+    assert first.access_token == "AT-1"
+    assert second.access_token == "AT-1", "grace-cache hit must return the same OAuthToken"
+    assert second.refresh_token == "RT-1"
+
+
+def test_exchange_grace_window_expires(monkeypatch, restore_oauth_proxy):
+    """After the grace window passes, the underlying exchange runs again."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "1")
+    OAuthProxy = restore_oauth_proxy
+
+    call_count = {"n": 0}
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        call_count["n"] += 1
+        return OAuthToken(access_token=f"AT-{call_count['n']}", token_type="Bearer", expires_in=3600)
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-original")
+
+    async def _scenario():
+        await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["s"])  # n=1
+        await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["s"])  # cache hit, n=1
+        await asyncio.sleep(1.2)
+        await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["s"])  # n=2
+
+    _run(_scenario())
+    assert call_count["n"] == 2, "expired entry must trigger a fresh underlying call"
+
+
+def test_load_refresh_token_synthesizes_from_grace_cache(monkeypatch, restore_oauth_proxy):
+    """When original load returns None, patched load synthesizes from cache."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        return OAuthToken(access_token="AT", token_type="Bearer", expires_in=3600)
+
+    async def fake_load_returning_none(self, client, refresh_token):
+        return None
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+    OAuthProxy.load_refresh_token = fake_load_returning_none
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-original")
+
+    # First exchange populates the grace cache
+    _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    # Now ask load_refresh_token for the same RT string -> should be synthesized
+    synthesized = _run(OAuthProxy.load_refresh_token(proxy, client, "rt-original"))
+    assert synthesized is not None
+    assert synthesized.client_id == "client-abc"
+    assert "openid" in synthesized.scopes
+    # And a totally-unknown RT still misses
+    miss = _run(OAuthProxy.load_refresh_token(proxy, client, "rt-never-issued"))
+    assert miss is None
+
+
+def test_load_refresh_token_passes_through_when_original_returns(monkeypatch, restore_oauth_proxy):
+    """If original load returns a RefreshToken, patched load returns it unchanged."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+
+    from mcp.server.auth.provider import RefreshToken
+
+    sentinel = RefreshToken(
+        token="rt-x", client_id="client-x", scopes=["s"], expires_at=int(time.time() + 600)
+    )
+
+    async def fake_load(self, client, refresh_token):
+        return sentinel
+
+    OAuthProxy.load_refresh_token = fake_load
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-x")
+    out = _run(OAuthProxy.load_refresh_token(proxy, client, "rt-x"))
+    assert out is sentinel
+
+
+def test_grace_cache_rejects_cross_client_replay(monkeypatch, restore_oauth_proxy):
+    """A cached entry must only be honored for the original client_id."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        return OAuthToken(access_token="AT", token_type="Bearer", expires_in=3600)
+
+    async def fake_load_returning_none(self, client, refresh_token):
+        return None
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+    OAuthProxy.load_refresh_token = fake_load_returning_none
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch()
+
+    proxy = SimpleNamespace()
+    client_a = SimpleNamespace(client_id="client-A")
+    client_b = SimpleNamespace(client_id="client-B")
+    rt = SimpleNamespace(token="rt-shared")
+
+    # Client A exchanges; cache holds (OAuthToken, "client-A", ["openid"])
+    _run(OAuthProxy.exchange_refresh_token(proxy, client_a, rt, ["openid"]))
+
+    # Client B presents the same RT string -> grace cache must NOT synthesize
+    out = _run(OAuthProxy.load_refresh_token(proxy, client_b, "rt-shared"))
+    assert out is None

--- a/tests/test_rewrap_oauth_clients.py
+++ b/tests/test_rewrap_oauth_clients.py
@@ -1,0 +1,78 @@
+"""Tests for the OAuth client doc rewrap helper used in key rotation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from key_value.aio.stores.memory import MemoryStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _new_key() -> bytes:
+    return Fernet.generate_key()
+
+
+def test_rewrap_round_trip_with_multifernet_moves_ciphertext_to_newest_key():
+    """End-to-end model of what the rewrap script does in production.
+
+    1. Write a client doc encrypted with OLD key.
+    2. Open a MultiFernet([NEW, OLD]) wrapper. Get returns the cleartext.
+    3. Put the same value back -- now stored under NEW.
+    4. Verify the new ciphertext is decryptable by NEW alone and
+       NOT by OLD alone.
+    """
+    old_key = _new_key()
+    new_key = _new_key()
+    backing = MemoryStore()
+
+    async def _scenario():
+        # 1. Original write under OLD key.
+        old_wrapper = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(old_key))
+        await old_wrapper.put(key="client-abc", value={"client_id": "client-abc", "name": "x"})
+
+        # 2. & 3. Rewrap pass: open MultiFernet wrapper, read+write.
+        mf = MultiFernet([Fernet(new_key), Fernet(old_key)])
+        mf_wrapper = FernetEncryptionWrapper(key_value=backing, fernet=mf)
+        value = await mf_wrapper.get(key="client-abc")
+        assert value == {"client_id": "client-abc", "name": "x"}
+        await mf_wrapper.put(key="client-abc", value=value)
+
+        # 4. Post-rewrap: NEW-only wrapper succeeds; OLD-only fails.
+        new_only = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(new_key))
+        assert await new_only.get(key="client-abc") == {"client_id": "client-abc", "name": "x"}
+
+        old_only = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(old_key))
+        from key_value.aio.errors import DecryptionError
+        with pytest.raises(DecryptionError):
+            await old_only.get(key="client-abc")
+
+    _run(_scenario())
+
+
+def test_rewrap_skips_docs_unreadable_by_any_listed_key():
+    """A doc encrypted with a never-listed key surfaces as DecryptionError.
+
+    The rewrap script logs and continues; this test just confirms the
+    underlying stack raises so the script's failure path triggers.
+    """
+    orphan_key = _new_key()
+    new_key = _new_key()
+    backing = MemoryStore()
+
+    async def _scenario():
+        orphan_wrapper = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(orphan_key))
+        await orphan_wrapper.put(key="orphan", value={"x": 1})
+
+        mf = MultiFernet([Fernet(new_key)])  # orphan_key NOT listed
+        mf_wrapper = FernetEncryptionWrapper(key_value=backing, fernet=mf)
+        from key_value.aio.errors import DecryptionError
+        with pytest.raises(DecryptionError):
+            await mf_wrapper.get(key="orphan")
+
+    _run(_scenario())

--- a/tests/test_storage_healing_patch.py
+++ b/tests/test_storage_healing_patch.py
@@ -46,12 +46,13 @@ def test_passthrough_when_get_client_succeeds(monkeypatch):
     provider._client_store.delete.assert_not_called()
 
 
-def test_heals_on_invalid_token_decryption_failure(monkeypatch, caplog):
+def test_heals_on_real_decryption_error_from_keyvalue_wrapper(monkeypatch, caplog):
+    """Primary prod path: FernetEncryptionWrapper raises DecryptionError."""
     monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
-    from cryptography.fernet import InvalidToken
+    from key_value.aio.errors import DecryptionError
 
     async def boom(client_id):
-        raise InvalidToken("ciphertext can't be decrypted")
+        raise DecryptionError("Failed to decrypt value")
 
     provider = _make_provider(boom)
     _fresh_module().apply_storage_healing_patch(provider)
@@ -69,7 +70,40 @@ def test_heals_on_invalid_token_decryption_failure(monkeypatch, caplog):
     )
 
 
-def test_heals_on_pydantic_validation_error(monkeypatch):
+def test_heals_on_real_deserialization_error_from_pydantic_adapter(monkeypatch):
+    """Primary prod path: PydanticAdapter raises DeserializationError."""
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
+    from key_value.aio.errors import DeserializationError
+
+    async def boom(client_id):
+        raise DeserializationError("Invalid ProxyDCRClient: [...]")
+
+    provider = _make_provider(boom)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    out = _run(provider.get_client("client-xyz"))
+    assert out is None
+    provider._client_store.delete.assert_awaited_once_with(key="client-xyz")
+
+
+def test_defense_in_depth_invalid_token(monkeypatch):
+    """Defensive catch: bare cryptography.InvalidToken (in case wrapper changes)."""
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
+    from cryptography.fernet import InvalidToken
+
+    async def boom(client_id):
+        raise InvalidToken("ciphertext can't be decrypted")
+
+    provider = _make_provider(boom)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    out = _run(provider.get_client("client-xyz"))
+    assert out is None
+    provider._client_store.delete.assert_awaited_once_with(key="client-xyz")
+
+
+def test_defense_in_depth_pydantic_validation_error(monkeypatch):
+    """Defensive catch: bare pydantic.ValidationError."""
     monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
     from pydantic import BaseModel, ValidationError
 
@@ -94,10 +128,10 @@ def test_heals_on_pydantic_validation_error(monkeypatch):
 
 def test_heal_disabled_skips_delete_but_still_returns_none(monkeypatch, caplog):
     monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "false")
-    from cryptography.fernet import InvalidToken
+    from key_value.aio.errors import DecryptionError
 
     async def boom(client_id):
-        raise InvalidToken("nope")
+        raise DecryptionError("nope")
 
     provider = _make_provider(boom)
     _fresh_module().apply_storage_healing_patch(provider)

--- a/tests/test_storage_healing_patch.py
+++ b/tests/test_storage_healing_patch.py
@@ -1,0 +1,129 @@
+"""Tests for the storage self-healing patch (Fix C.2)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _fresh_module():
+    sys.modules.pop("storage_healing_patch", None)
+    return importlib.import_module("storage_healing_patch")
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_provider(get_client_impl):
+    """Build a stub OAuthProxy-shaped object."""
+    provider = SimpleNamespace()
+    provider.get_client = get_client_impl  # bound-method-ish; the patch
+    #                                       captures this and rebinds via
+    #                                       types.MethodType.
+    provider._client_store = SimpleNamespace(delete=AsyncMock(return_value=True))
+    return provider
+
+
+def test_passthrough_when_get_client_succeeds(monkeypatch):
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
+    sentinel = object()
+
+    async def ok(client_id):
+        return sentinel
+
+    provider = _make_provider(ok)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    out = _run(provider.get_client("client-abc"))
+    assert out is sentinel
+    provider._client_store.delete.assert_not_called()
+
+
+def test_heals_on_invalid_token_decryption_failure(monkeypatch, caplog):
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
+    from cryptography.fernet import InvalidToken
+
+    async def boom(client_id):
+        raise InvalidToken("ciphertext can't be decrypted")
+
+    provider = _make_provider(boom)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    with caplog.at_level(logging.ERROR, logger="boomi.storage_healing"):
+        out = _run(provider.get_client("client-abc-with-very-long-id-string"))
+
+    assert out is None
+    provider._client_store.delete.assert_awaited_once_with(
+        key="client-abc-with-very-long-id-string"
+    )
+    assert any(
+        "Corrupted oauth client document detected" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_heals_on_pydantic_validation_error(monkeypatch):
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
+    from pydantic import BaseModel, ValidationError
+
+    class _T(BaseModel):
+        x: int
+
+    try:
+        _T(x="not-an-int")
+    except ValidationError as captured:
+        validation_error = captured
+
+    async def boom(client_id):
+        raise validation_error
+
+    provider = _make_provider(boom)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    out = _run(provider.get_client("client-xyz"))
+    assert out is None
+    provider._client_store.delete.assert_awaited_once_with(key="client-xyz")
+
+
+def test_heal_disabled_skips_delete_but_still_returns_none(monkeypatch, caplog):
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "false")
+    from cryptography.fernet import InvalidToken
+
+    async def boom(client_id):
+        raise InvalidToken("nope")
+
+    provider = _make_provider(boom)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    with caplog.at_level(logging.ERROR, logger="boomi.storage_healing"):
+        out = _run(provider.get_client("client-xyz"))
+
+    assert out is None
+    provider._client_store.delete.assert_not_called()
+    # ERROR log still fires so operators see the corruption.
+    assert any(
+        "Corrupted oauth client document detected" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_non_decryption_exceptions_propagate(monkeypatch):
+    """Random errors (network, code bugs) must NOT be swallowed by healing."""
+    monkeypatch.setenv("BOOMI_AUTH_HEAL_CORRUPT_CLIENTS", "true")
+
+    async def boom(client_id):
+        raise RuntimeError("mongodb unreachable")
+
+    provider = _make_provider(boom)
+    _fresh_module().apply_storage_healing_patch(provider)
+
+    with pytest.raises(RuntimeError, match="mongodb unreachable"):
+        _run(provider.get_client("client-abc"))
+    provider._client_store.delete.assert_not_called()


### PR DESCRIPTION
## Summary

Implements `docs/plans/oauth_refresh_failure_hardening_plan.json` (Fix A + C.1 + C.2 + C.3). Fix B (Google verifier cache) is the separate `oauth_token_verifier_cache_plan.json` — not in this PR.

All four sub-fixes target the three independent root causes of *"MCP becomes inaccessible after ~1h without LLM session reload"* identified in the prior root-cause pass:

- **Fix A — Refresh-token rotation grace window** (60s, env-tunable). Upstream FastMCP v3.1.1 enforces one-time-use refresh tokens; any client retry-after-blip or parallel-tab refresh triggers `Refresh token mapping not found` → permanent 401. The grace window returns the same rotated tokens for a configurable window so the same RT presented twice within ~60s no longer locks the user out. Same pattern Auth0 ("reuse interval") and AWS Cognito ("reuse grace") use. Server-side patch only; no client change.
- **Fix C.1 — OAuth diagnostics on by default**. The three diagnostic patches in `diagnostic_logging.py` (token-endpoint client auth, client lookup, encrypted storage GET) are no longer gated by `BOOMI_OAUTH_DIAGNOSTICS=true`. Off-switch is now `BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true`; the legacy `BOOMI_OAUTH_DIAGNOSTICS=false` still opts out for back-compat. Pinned ON in `k8s/deployment.yaml`.
- **Fix C.2 — Storage self-healing**. New `storage_healing_patch.py` wraps `OAuthProxy.get_client` after the diagnostic wrapper. On `InvalidToken` / `pydantic.ValidationError` it logs ERROR, deletes the corrupted MongoDB doc (`mcp-oauth-proxy-clients`), and returns `None` so the client falls into Dynamic Client Registration on retry. `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS=false` keeps the log-only behavior.
- **Fix C.3 — MultiFernet for STORAGE_ENCRYPTION_KEY**. Comma-separated value (newest first) wraps in `MultiFernet`; single value remains plain `Fernet`. Enables zero-downtime key rotation. Procedure documented in the runbook.

## Diff

```
.env.example                            |  27 +++
README.md                               |  26 +++-
diagnostic_logging.py                   |  30 ++-
docs/oauth-migration-runbook.md         |  59 +++-
k8s/deployment.yaml                     |   7 +
refresh_token_grace_patch.py            | 156 +++ (new)
server.py                               |  48 +-
storage_healing_patch.py                | 105 +++ (new)
tests/test_multifernet_rotation.py      | 119 +++ (new)
tests/test_refresh_token_grace_patch.py | 244 +++ (new)
tests/test_storage_healing_patch.py     | 129 +++ (new)
```

5 commits, 925 insertions / 25 deletions. All four sub-fixes are independent env-var gated.

## Test plan

- [x] Full local pytest suite: **296 passed**
- [x] Targeted suites for new patches:
  - `tests/test_refresh_token_grace_patch.py` (9 tests — cache primitive, env gating, two-call coalescing, expiry, cross-client mismatch defense, RefreshToken passthrough/synthesis)
  - `tests/test_storage_healing_patch.py` (5 tests — passthrough, InvalidToken heal, ValidationError heal, heal-disabled log-only, non-decryption exceptions propagate)
  - `tests/test_multifernet_rotation.py` (9 tests — single/multi key, MultiFernet round-trips, parsing whitespace + invalid + empty)
- [x] QA loop (per `CLAUDE.md`): `boomi-qa-tester` agent confirmed:
  - `import server` clean with new patch modules at root
  - patch modules import standalone
  - `LOCAL_MODE=true` correctly skips the OAuth setup block (no namespace bleed)
  - read-only tools execute via `.fn()` end-to-end (`list_capabilities`, `list_boomi_profiles`, `manage_folders`, `boomi_account_info`, `query_components`)

### Post-merge live smoke (separate from this PR)

- Confirm Cloud Run logs show `[INFO] OAuth diagnostic logging ENABLED` at startup
- Two concurrent `curl -d grant_type=refresh_token -d refresh_token=<same RT>` → both 200, same `access_token`; logs show `Refresh-token grace cache HIT`
- Repeat 70 s later with original RT → 401 `invalid_grant` (grace expired)
- Corrupt one client doc in MongoDB → `Corrupted oauth client document detected` ERROR line + doc deleted + 401; fresh DCR succeeds on next attempt
- Rotate `STORAGE_ENCRYPTION_KEY` to `"<new>,<old>"` per the runbook → old docs still decrypt; new writes use `<new>`

## Rollback

Each fix is independently gated; per-fix off-switches documented in `docs/oauth-migration-runbook.md` and `README.md`:

| Fix | Off-switch |
|---|---|
| A — RT grace window | `BOOMI_RT_GRACE_SECONDS=0` |
| C.1 — diagnostics | `BOOMI_OAUTH_DIAGNOSTICS_DISABLE=true` |
| C.2 — storage heal | `BOOMI_AUTH_HEAL_CORRUPT_CLIENTS=false` |
| C.3 — MultiFernet | revert to single-value `STORAGE_ENCRYPTION_KEY` |

Full rollback: `git revert <merge_commit>`. No data migrations, no schema changes.