### PR TITLE
harden oauth cache path: per-process verifier cache + cross-instance grace (mongo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,30 @@ GCP_PROJECT_ID=your-gcp-project-id
 # STORAGE_ENCRYPTION_KEY supports a comma-separated list of Fernet keys
 # (newest first) for zero-downtime rotation via MultiFernet:
 # STORAGE_ENCRYPTION_KEY=<new-key>,<old-key>
+
+# =============================================================================
+# OAUTH CACHE HARDENING (optional, safe defaults applied)
+# =============================================================================
+# See docs/oauth-migration-runbook.md for the rollout + rollback procedure.
+
+# Per-process Google verifier cache (Fix B). Reduces per-tool-call
+# tokeninfo/userinfo round trips to roughly one per cache TTL.
+# BOOMI_TOKEN_CACHE_DISABLE=true
+# BOOMI_TOKEN_CACHE_TTL_SECONDS=300
+# BOOMI_TOKEN_CACHE_MAX_SIZE=256
+# BOOMI_TOKEN_CACHE_SWR=true
+# BOOMI_TOKEN_CACHE_SWR_WINDOW=30
+
+# Cross-instance refresh-token grace cache (Fix D). MongoDB-backed,
+# Fernet-encrypted via STORAGE_ENCRYPTION_KEY. On by default in
+# production; the helper falls back to per-process-only if MongoDB is
+# unreachable. Collection: mcp-rt-grace.
+# BOOMI_RT_GRACE_SHARED=false
+# BOOMI_RT_GRACE_SHARED_COLLECTION=mcp-rt-grace
+
+# Distributed singleflight (Fix D.2). Opt-in. Enable only after Fix D
+# logs show duplicate orig_exchange calls within milliseconds for the
+# same RT hash across replicas. Collection: mcp-rt-inflight-locks.
+# BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true
+# BOOMI_RT_GRACE_LOCK_TTL_SECONDS=30
+# BOOMI_RT_GRACE_LOCK_POLL_MS=100

--- a/README.md
+++ b/README.md
@@ -261,6 +261,38 @@ BOOMI_AUTH_HEAL_CORRUPT_CLIENTS # default true. When get_client raises
                                 # re-register cleanly.
 ```
 
+#### OAuth cache hardening (optional)
+
+Closes the remaining Google-call and cross-instance gaps. All ship
+with safe defaults; see `docs/oauth-migration-runbook.md` for the
+rollout and rollback procedure.
+
+```bash
+BOOMI_TOKEN_CACHE_DISABLE           # default off (cache ON). Set true to
+                                    # restore the per-tool-call Google
+                                    # tokeninfo/userinfo round trip.
+BOOMI_TOKEN_CACHE_TTL_SECONDS       # default 300. Upper bound on per-entry
+                                    # TTL; caps Google-revocation latency.
+BOOMI_TOKEN_CACHE_MAX_SIZE          # default 256. LRU capacity.
+BOOMI_TOKEN_CACHE_SWR               # default false. Opt-in stale-while-
+                                    # revalidate against short Google outages.
+BOOMI_TOKEN_CACHE_SWR_WINDOW        # default 30. Seconds before expiry at
+                                    # which SWR serves stale + refreshes.
+
+BOOMI_RT_GRACE_SHARED               # default true. Backs the refresh-token
+                                    # grace cache with a MongoDB collection
+                                    # (mcp-rt-grace, Fernet-encrypted) so
+                                    # multi-replica deployments coalesce
+                                    # rotations across instances.
+BOOMI_RT_GRACE_SHARED_COLLECTION    # default mcp-rt-grace.
+BOOMI_RT_GRACE_DISTRIBUTED_LOCK     # default false. Opt-in cross-instance
+                                    # singleflight via mcp-rt-inflight-locks.
+                                    # Enable only if logs show duplicate
+                                    # orig_exchange calls within ms.
+BOOMI_RT_GRACE_LOCK_TTL_SECONDS     # default 30. Auto-release safety bound.
+BOOMI_RT_GRACE_LOCK_POLL_MS         # default 100. Follower poll interval.
+```
+
 #### User Credentials Storage
 
 User Boomi API credentials are stored separately in GCP Secret Manager:

--- a/docs/oauth-migration-runbook.md
+++ b/docs/oauth-migration-runbook.md
@@ -194,3 +194,82 @@ gcloud secrets versions add storage-encryption-key \
 If step 3 reports `decrypt_failed > 0`, do **not** drop the old key.
 Either restore the missing historical key, or accept that the listed
 clients will need to re-register, then re-run before dropping.
+
+## OAuth cache hardening (2026-05-18, second pass)
+
+Closes the two cache-shaped gaps the original hardening PR left open:
+
+- **Fix B — Google verifier cache.** Caches the `AccessToken` returned
+  by `GoogleTokenVerifier.verify_token` in-process so a burst of MCP
+  tool calls from one authed session triggers exactly one
+  `tokeninfo`+`userinfo` round trip per cache TTL (default 5 min)
+  instead of two Google calls per tool call. Transient Google
+  rate-limits become cache hits instead of silent 401 cascades.
+
+- **Fix D — Cross-instance grace cache.** Backs the per-process
+  refresh-token grace cache (from the first hardening pass) with a
+  Fernet-encrypted MongoDB collection so a rotation that lands on
+  Cloud Run replica A is visible to replica B during the grace window.
+  Closes the multi-instance `Refresh token mapping not found` 401 that
+  the per-process cache alone could not prevent.
+
+- **Fix D.2 — Distributed singleflight (opt-in, off by default).**
+  When two replicas start refreshing the same RT at exactly the same
+  millisecond, the per-replica leader claims a Mongo lock row; the
+  losing replica polls the shared cache for the result. Off by default
+  because the L2 cache (Fix D) closes most of the race; enable only if
+  you observe duplicate `orig_exchange` calls in the diagnostic logs.
+
+### New env vars
+
+All five ship with safe defaults. Override only when debugging or
+tuning Google call volume.
+
+| Env var | Default | Purpose | Off-switch |
+|---|---|---|---|
+| `BOOMI_TOKEN_CACHE_DISABLE` | unset (= cache ON) | Bypass Fix B entirely; every MCP tool call hits Google `tokeninfo`/`userinfo` as before. | Set to `true` |
+| `BOOMI_TOKEN_CACHE_TTL_SECONDS` | `300` | Upper bound on per-entry TTL. Caps the window in which a Google-side token revocation is not honored. | Lower to e.g. `60` |
+| `BOOMI_TOKEN_CACHE_MAX_SIZE` | `256` | LRU capacity for the verifier cache. | — |
+| `BOOMI_TOKEN_CACHE_SWR` | `false` | Opt-in stale-while-revalidate; serves stale within `BOOMI_TOKEN_CACHE_SWR_WINDOW` and refreshes in the background. | Set to `false` |
+| `BOOMI_TOKEN_CACHE_SWR_WINDOW` | `30` | Seconds before a cached entry's expiry at which SWR returns stale and schedules a refresh. | — |
+| `BOOMI_RT_GRACE_SHARED` | `true` (when `MONGODB_URI` is set) | Enables the Fix D shared MongoDB-backed grace cache (`mcp-rt-grace`). | Set to `false` |
+| `BOOMI_RT_GRACE_SHARED_COLLECTION` | `mcp-rt-grace` | Collection name override; unlikely to need outside tests. | — |
+| `BOOMI_RT_GRACE_DISTRIBUTED_LOCK` | `false` | Opt-in Fix D.2 cross-instance singleflight via the `mcp-rt-inflight-locks` collection. | Set to `false` |
+| `BOOMI_RT_GRACE_LOCK_TTL_SECONDS` | `30` | Safety bound on Fix D.2 lock rows. A crashed leader auto-releases via the collection's TTL index. | — |
+| `BOOMI_RT_GRACE_LOCK_POLL_MS` | `100` | Fix D.2 follower polling interval against the shared cache. | — |
+
+### New MongoDB collections
+
+- `mcp-rt-grace` — Fix D shared grace cache. Fernet-encrypted via the
+  same `STORAGE_ENCRYPTION_KEY` (MultiFernet-aware) as the rest of
+  OAuth state. One row per active old refresh-token hash, auto-evicted
+  by the underlying store's TTL handling (~60s default lifetime).
+- `mcp-rt-inflight-locks` — Fix D.2 only. One row per in-flight refresh
+  across the fleet, auto-evicted via a TTL index on `expires_at` so a
+  crashed leader instance does not deadlock subsequent refreshes
+  longer than `BOOMI_RT_GRACE_LOCK_TTL_SECONDS`.
+
+Both collections live in the same `boomi_mcp` database. Neither needs
+explicit cleanup — they grow proportional to refresh-token rotation
+volume and auto-evict via TTL.
+
+### Rollout
+
+Recommended phases (matching `docs/plans/oauth_token_verifier_cache_plan.json`):
+
+1. Merge with defaults (Fix B on, Fix D on, Fix D.2 off). Tail logs
+   for a week. Confirm Google `tokeninfo` call rate drops ~92 % and
+   the cross-replica `invalid_grant` rate from `mcp-rt-grace` is near
+   zero.
+2. If `Refresh-token grace SHARED HIT` lines from a replica that did
+   not perform the original rotation appear in the diagnostic logs,
+   Fix D is working. If duplicate `orig_exchange` calls for the same
+   hash within milliseconds appear, set
+   `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true` and redeploy (config-only).
+
+### Rollback
+
+Per-fix off-switches: set `BOOMI_TOKEN_CACHE_DISABLE=true`,
+`BOOMI_RT_GRACE_SHARED=false`, or `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=false`.
+Full rollback: `git revert <merge_commit>`. The two new MongoDB
+collections auto-evict via TTL; explicit cleanup is optional.

--- a/refresh_token_grace_patch.py
+++ b/refresh_token_grace_patch.py
@@ -60,7 +60,7 @@ class _TTLCache:
                 self._data.popitem(last=False)
 
 
-def apply_refresh_token_grace_patch() -> None:
+def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
     """Install the grace-window monkey-patches on OAuthProxy.
 
     Idempotent at import time: applies once per Python process. Calling
@@ -68,6 +68,14 @@ def apply_refresh_token_grace_patch() -> None:
     methods with functionally identical wrappers (the inner cache is
     re-created, which is acceptable -- there are no live tokens at
     server startup).
+
+    Args:
+        shared_backend: Optional rt_grace_shared_backend.SharedGraceBackend
+            instance. When provided, the leader's rotated tokens are
+            written through to the shared backend after orig_exchange
+            succeeds, and followers on the same OR other Cloud Run
+            replicas consult the shared backend on local cache miss.
+            When None, behavior matches PR #33 (per-process only).
     """
     grace_seconds = int(os.getenv("BOOMI_RT_GRACE_SECONDS", "60"))
     if grace_seconds <= 0:
@@ -93,9 +101,45 @@ def apply_refresh_token_grace_patch() -> None:
     from fastmcp.server.auth.oauth_proxy.models import _hash_token
     from fastmcp.server.auth.oauth_proxy.proxy import OAuthProxy
     from mcp.server.auth.provider import RefreshToken
+    from mcp.shared.auth import OAuthToken
 
     orig_load_refresh_token = OAuthProxy.load_refresh_token
     orig_exchange_refresh_token = OAuthProxy.exchange_refresh_token
+
+    def _serialize(oauth_token, client_id, scopes_list):
+        """OAuthToken + identity -> JSON-friendly dict for the shared backend."""
+        return {
+            "access_token": oauth_token.access_token,
+            "token_type": oauth_token.token_type,
+            "expires_in": oauth_token.expires_in,
+            "refresh_token": oauth_token.refresh_token,
+            "scope": oauth_token.scope,
+            "client_id": client_id,
+            "scopes": list(scopes_list),
+        }
+
+    def _deserialize(payload):
+        """Shared-backend payload -> (OAuthToken, client_id, scopes_list)."""
+        return (
+            OAuthToken(
+                access_token=payload["access_token"],
+                token_type=payload.get("token_type", "Bearer"),
+                expires_in=payload.get("expires_in"),
+                refresh_token=payload.get("refresh_token"),
+                scope=payload.get("scope"),
+            ),
+            payload.get("client_id"),
+            payload.get("scopes") or [],
+        )
+
+    async def _shared_get(old_hash):
+        """Return (OAuthToken, client_id, scopes) from the shared backend, or None."""
+        if shared_backend is None:
+            return None
+        payload = await shared_backend.get(old_hash)
+        if not payload or "access_token" not in payload:
+            return None
+        return _deserialize(payload)
 
     async def patched_load_refresh_token(self, client, refresh_token):
         result = await orig_load_refresh_token(self, client, refresh_token)
@@ -122,7 +166,15 @@ def apply_refresh_token_grace_patch() -> None:
 
         cached = await cache.get(old_hash)
         if cached is None:
-            return None
+            # Local L1 miss. Consult the shared L2 (Fix D) -- a leader on
+            # ANOTHER Cloud Run replica may have already rotated this RT.
+            cached = await _shared_get(old_hash)
+            if cached is None:
+                return None
+            logger.info(
+                "Refresh-token grace SHARED HIT in load (client=%s)",
+                (client.client_id or "<none>")[:8],
+            )
 
         oauth_token, cached_client_id, cached_scopes = cached
         # Cross-client reuse defense: only honor the grace entry for the
@@ -162,14 +214,40 @@ def apply_refresh_token_grace_patch() -> None:
             )
             return oauth_token
 
+        # Shared L2 fast path: a leader on ANOTHER replica may have
+        # already rotated. If so, return their result and skip both the
+        # local singleflight and any upstream call.
+        shared_cached = await _shared_get(old_hash)
+        if shared_cached is not None:
+            oauth_token, _cid, _scp = shared_cached
+            # Warm the local L1 cache so subsequent calls on this replica
+            # don't pay the shared-get latency again.
+            await cache.set(
+                old_hash, shared_cached, time.time() + grace_seconds
+            )
+            logger.info(
+                "Refresh-token grace SHARED HIT in exchange (client=%s)",
+                client_id_repr,
+            )
+            return oauth_token
+
         # Singleflight: claim the slot or piggyback on the in-flight leader.
         is_leader = False
         async with inflight_lock:
-            # Re-check the cache under the lock to close the obvious
+            # Re-check the local cache under the lock to close the obvious
             # check-then-act race against a leader that just finished.
             cached = await cache.get(old_hash)
             if cached is not None:
                 return cached[0]
+            # Also re-check the shared cache under the lock so a write from
+            # another replica between the fast-path check and lock entry
+            # is observed before we needlessly claim a singleflight slot.
+            shared_cached = await _shared_get(old_hash)
+            if shared_cached is not None:
+                await cache.set(
+                    old_hash, shared_cached, time.time() + grace_seconds
+                )
+                return shared_cached[0]
             future = inflight.get(old_hash)
             if future is None:
                 future = asyncio.get_event_loop().create_future()
@@ -200,6 +278,15 @@ def apply_refresh_token_grace_patch() -> None:
             (result, client.client_id, list(scopes)),
             time.time() + grace_seconds,
         )
+        # Write through to the shared backend (Fix D). The backend
+        # swallows storage errors and logs WARNING, so the local caller
+        # is never blocked by a Mongo blip.
+        if shared_backend is not None:
+            await shared_backend.put(
+                old_hash,
+                _serialize(result, client.client_id, list(scopes)),
+                grace_seconds,
+            )
         async with inflight_lock:
             inflight.pop(old_hash, None)
         if not future.done():
@@ -209,7 +296,8 @@ def apply_refresh_token_grace_patch() -> None:
     OAuthProxy.load_refresh_token = patched_load_refresh_token
     OAuthProxy.exchange_refresh_token = patched_exchange_refresh_token
     logger.info(
-        "Refresh-token grace window ENABLED (%ds, max_size=%d, singleflight=on)",
+        "Refresh-token grace window ENABLED (%ds, max_size=%d, singleflight=on, shared_backend=%s)",
         grace_seconds,
         max_size,
+        "on" if shared_backend is not None else "off",
     )

--- a/refresh_token_grace_patch.py
+++ b/refresh_token_grace_patch.py
@@ -85,6 +85,19 @@ def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
     max_size = int(os.getenv("BOOMI_RT_GRACE_MAX_SIZE", "512"))
     cache = _TTLCache(max_size=max_size)
 
+    # Fix D.2: distributed singleflight settings (opt-in).
+    distributed_lock_enabled = (
+        shared_backend is not None
+        and getattr(shared_backend, "supports_locks", False)
+    )
+    lock_ttl_seconds = int(os.getenv("BOOMI_RT_GRACE_LOCK_TTL_SECONDS", "30"))
+    lock_poll_seconds = max(
+        0.01, int(os.getenv("BOOMI_RT_GRACE_LOCK_POLL_MS", "100")) / 1000.0
+    )
+
+    import socket
+    instance_id = os.getenv("HOSTNAME") or socket.gethostname() or "unknown"
+
     # Per-token singleflight: ensures only one call into the underlying
     # OAuthProxy.exchange_refresh_token runs for each old refresh-token
     # hash, even under concurrent (parallel-tab / network-retry) load.
@@ -133,13 +146,43 @@ def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
         )
 
     async def _shared_get(old_hash):
-        """Return (OAuthToken, client_id, scopes) from the shared backend, or None."""
+        """Return (OAuthToken, client_id, scopes) from the shared backend, or None.
+
+        Returns None for a payload missing the access_token field (e.g.,
+        a Fix-D.2 failure marker placeholder); the failure-marker case is
+        handled separately by `_poll_shared_for_result`.
+        """
         if shared_backend is None:
             return None
         payload = await shared_backend.get(old_hash)
         if not payload or "access_token" not in payload:
             return None
         return _deserialize(payload)
+
+    async def _poll_shared_for_result(old_hash, max_wait_seconds, poll_seconds):
+        """Fix D.2 follower: poll the shared backend until the leader
+        publishes a result, a failure marker, or we time out.
+
+        Returns:
+            (OAuthToken, client_id, scopes) on success.
+            Raises TokenError on a failure marker (so the framework returns
+            the same invalid_grant 401 the local leader would have).
+            None on timeout (caller falls through to best-effort orig).
+        """
+        from mcp.server.auth.provider import TokenError
+        deadline = time.time() + max_wait_seconds
+        while time.time() < deadline:
+            payload = await shared_backend.get(old_hash) if shared_backend else None
+            if payload:
+                if "error" in payload:
+                    raise TokenError(
+                        "invalid_grant",
+                        f"Refresh rotation failed on peer instance: {payload['error']}",
+                    )
+                if "access_token" in payload:
+                    return _deserialize(payload)
+            await asyncio.sleep(poll_seconds)
+        return None
 
     async def patched_load_refresh_token(self, client, refresh_token):
         result = await orig_load_refresh_token(self, client, refresh_token)
@@ -263,41 +306,110 @@ def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
             # same TokenError to all racing callers.
             return await future
 
-        # Leader path: run the real exchange, populate the cache, and
-        # release the singleflight slot regardless of outcome.
+        # Leader path: we hold the local singleflight slot. If Fix D.2
+        # is enabled, also try to claim the cross-instance lock. If we
+        # don't get the distributed lock, become a remote-follower:
+        # poll the shared backend for the result the OTHER replica is
+        # producing. If we time out, fall through to orig (best-effort
+        # degrade -- same outcome as if D.2 were disabled).
+        distributed_lock_held = False
         try:
-            result = await orig_exchange_refresh_token(self, client, refresh_token, scopes)
-        except BaseException as exc:
+            if distributed_lock_enabled:
+                distributed_lock_held = await shared_backend.try_claim_lock(
+                    old_hash, lock_ttl_seconds, instance_id
+                )
+                if not distributed_lock_held:
+                    logger.info(
+                        "Refresh-token grace DISTRIBUTED FOLLOWER (client=%s, instance=%s)",
+                        client_id_repr,
+                        instance_id,
+                    )
+                    remote_result = await _poll_shared_for_result(
+                        old_hash, lock_ttl_seconds, lock_poll_seconds
+                    )
+                    if remote_result is not None:
+                        oauth_token, _cid, _scp = remote_result
+                        await cache.set(
+                            old_hash, remote_result, time.time() + grace_seconds
+                        )
+                        # Release the local singleflight to local followers
+                        # waiting on our future.
+                        async with inflight_lock:
+                            inflight.pop(old_hash, None)
+                        if not future.done():
+                            future.set_result(oauth_token)
+                        return oauth_token
+                    # Timed out waiting on the remote leader -- best-effort
+                    # fall through to orig. Try again to claim the lock so
+                    # we don't double-rotate gratuitously; if we still fail,
+                    # proceed anyway.
+                    distributed_lock_held = await shared_backend.try_claim_lock(
+                        old_hash, lock_ttl_seconds, instance_id
+                    )
+                    logger.warning(
+                        "Refresh-token grace DISTRIBUTED FOLLOWER timed out "
+                        "for client=%s -- proceeding with orig_exchange",
+                        client_id_repr,
+                    )
+
+            try:
+                result = await orig_exchange_refresh_token(self, client, refresh_token, scopes)
+            except BaseException as exc:
+                # On leader exception, write a short-lived failure marker
+                # so remote followers see the failure within ~5s instead
+                # of waiting the full lock TTL.
+                if distributed_lock_held:
+                    try:
+                        await shared_backend.write_failure_marker(
+                            old_hash, type(exc).__name__
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+                async with inflight_lock:
+                    inflight.pop(old_hash, None)
+                if not future.done():
+                    future.set_exception(exc)
+                    # Mark the exception as retrieved so Python doesn't warn
+                    # on GC when there are no local followers awaiting it.
+                    try:
+                        future.exception()
+                    except (asyncio.CancelledError, asyncio.InvalidStateError):
+                        pass
+                raise
+
+            await cache.set(
+                old_hash,
+                (result, client.client_id, list(scopes)),
+                time.time() + grace_seconds,
+            )
+            # Write through to the shared backend (Fix D). The backend
+            # swallows storage errors and logs WARNING, so the local caller
+            # is never blocked by a Mongo blip.
+            if shared_backend is not None:
+                await shared_backend.put(
+                    old_hash,
+                    _serialize(result, client.client_id, list(scopes)),
+                    grace_seconds,
+                )
             async with inflight_lock:
                 inflight.pop(old_hash, None)
             if not future.done():
-                future.set_exception(exc)
-            raise
-        await cache.set(
-            old_hash,
-            (result, client.client_id, list(scopes)),
-            time.time() + grace_seconds,
-        )
-        # Write through to the shared backend (Fix D). The backend
-        # swallows storage errors and logs WARNING, so the local caller
-        # is never blocked by a Mongo blip.
-        if shared_backend is not None:
-            await shared_backend.put(
-                old_hash,
-                _serialize(result, client.client_id, list(scopes)),
-                grace_seconds,
-            )
-        async with inflight_lock:
-            inflight.pop(old_hash, None)
-        if not future.done():
-            future.set_result(result)
-        return result
+                future.set_result(result)
+            return result
+        finally:
+            if distributed_lock_held:
+                try:
+                    await shared_backend.release_lock(old_hash)
+                except Exception:  # noqa: BLE001
+                    pass
 
     OAuthProxy.load_refresh_token = patched_load_refresh_token
     OAuthProxy.exchange_refresh_token = patched_exchange_refresh_token
     logger.info(
-        "Refresh-token grace window ENABLED (%ds, max_size=%d, singleflight=on, shared_backend=%s)",
+        "Refresh-token grace window ENABLED (%ds, max_size=%d, singleflight=on, "
+        "shared_backend=%s, distributed_lock=%s)",
         grace_seconds,
         max_size,
         "on" if shared_backend is not None else "off",
+        "on" if distributed_lock_enabled else "off",
     )

--- a/rt_grace_shared_backend.py
+++ b/rt_grace_shared_backend.py
@@ -42,23 +42,34 @@ DEFAULT_LOCK_COLLECTION = "mcp-rt-inflight-locks"
 class SharedGraceBackend:
     """Async-safe wrapper around an AsyncKeyValue store.
 
-    Surface kept minimal: get / put / delete. The optional lock primitives
-    for Fix D.2 will be added in Phase 4.
+    Surface: get / put / delete for the L2 grace cache, plus optional
+    lock primitives for Fix D.2 (cross-instance singleflight).
 
     The wrapped store is expected to encrypt at rest (production wires
     FernetEncryptionWrapper). All exceptions on read are converted to
     `None` (corrupted grace entry is best-effort, never a hard 401).
     All exceptions on write are logged WARNING and swallowed (the
     in-process L1 cache still serves the local caller).
+
+    The optional `lock_collection` argument is a motor collection (raw
+    MongoDB client) used by `try_claim_lock`/`release_lock` for atomic
+    insert-or-fail semantics. When None, lock methods raise — callers
+    must check `supports_locks` before invoking them. Locks are only
+    needed when Fix D.2 is enabled (env BOOMI_RT_GRACE_DISTRIBUTED_LOCK).
     """
 
-    def __init__(self, key_value_store) -> None:
+    def __init__(self, key_value_store, lock_collection=None) -> None:
         # Deferred import so this module can be imported without the
         # encryption stack present (tests can pass in any AsyncKeyValue).
         from key_value.aio.errors import DecryptionError, DeserializationError
 
         self._store = key_value_store
         self._read_swallowed = (DecryptionError, DeserializationError)
+        self._lock_collection = lock_collection
+
+    @property
+    def supports_locks(self) -> bool:
+        return self._lock_collection is not None
 
     async def get(self, key: str) -> Optional[dict[str, Any]]:
         try:
@@ -95,6 +106,74 @@ class SharedGraceBackend:
                 exc,
             )
 
+    # ---- Fix D.2: distributed singleflight via Mongo upsert-as-lock ----
+
+    async def try_claim_lock(
+        self, key: str, ttl_seconds: int, instance: str
+    ) -> bool:
+        """Best-effort claim of an inflight-refresh lock for `key`.
+
+        Returns True if this caller got the lock (became leader);
+        False if another instance already holds it.
+
+        Failure modes: any unexpected exception is logged WARNING and
+        we return True (degrade to "no lock held" rather than
+        deadlocking the system). The lock collection has a TTL index on
+        `expires_at`, so a crashed leader auto-releases after at most
+        ttl_seconds + one Mongo TTL-sweep cycle.
+        """
+        if self._lock_collection is None:
+            raise RuntimeError(
+                "try_claim_lock called but SharedGraceBackend has no lock_collection. "
+                "Enable Fix D.2 via BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true."
+            )
+        from datetime import datetime, timedelta, timezone
+        from pymongo.errors import DuplicateKeyError
+        try:
+            await self._lock_collection.insert_one({
+                "_id": key,
+                "instance": instance,
+                "expires_at": datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds),
+            })
+            return True
+        except DuplicateKeyError:
+            return False
+        except Exception as exc:  # noqa: BLE001 — degrade to "no lock"
+            logger.warning(
+                "try_claim_lock fallthrough for key=%s: %s: %s",
+                key[:16] + "..." if key and len(key) > 16 else key,
+                type(exc).__name__,
+                exc,
+            )
+            return True
+
+    async def release_lock(self, key: str) -> None:
+        """Best-effort lock release. Safe to call even if we never held it."""
+        if self._lock_collection is None:
+            return
+        try:
+            await self._lock_collection.delete_one({"_id": key})
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "release_lock failed for key=%s: %s: %s",
+                key[:16] + "..." if key and len(key) > 16 else key,
+                type(exc).__name__,
+                exc,
+            )
+
+    async def write_failure_marker(
+        self, key: str, error_type: str, short_ttl: int = 5
+    ) -> None:
+        """Write a small failure marker so polling followers see the
+        leader's exception within ~short_ttl seconds rather than the
+        full lock TTL. The marker is detected by callers via the
+        sentinel `error` field in the payload."""
+        await self.put(
+            key,
+            {"error": error_type},
+            short_ttl,
+        )
+
 
 def initialize_shared_grace_backend(
     mongodb_uri: str,
@@ -130,6 +209,9 @@ def initialize_shared_grace_backend(
         raise ValueError("initialize_shared_grace_backend requires a Fernet/MultiFernet instance")
 
     collection = os.getenv("BOOMI_RT_GRACE_SHARED_COLLECTION", DEFAULT_COLLECTION)
+    distributed_lock_enabled = os.getenv(
+        "BOOMI_RT_GRACE_DISTRIBUTED_LOCK", "false"
+    ).lower() in ("true", "1", "yes")
 
     # Deferred imports keep this module importable in LOCAL_MODE.
     from key_value.aio.stores.mongodb import MongoDBStore
@@ -137,7 +219,47 @@ def initialize_shared_grace_backend(
 
     mongo_store = MongoDBStore(url=mongodb_uri, db_name=db_name, coll_name=collection)
     encrypted = FernetEncryptionWrapper(key_value=mongo_store, fernet=fernet)
-    backend = SharedGraceBackend(encrypted)
+
+    lock_collection = None
+    if distributed_lock_enabled:
+        # Fix D.2: stand up a raw motor collection for atomic upsert-as-lock
+        # semantics that the key_value abstraction doesn't expose. Best
+        # effort -- if motor can't be imported or the index can't be
+        # created, log WARNING and downgrade to grace-cache-only.
+        try:
+            from motor.motor_asyncio import AsyncIOMotorClient
+            client = AsyncIOMotorClient(mongodb_uri)
+            db = client[db_name]
+            lock_collection = db[DEFAULT_LOCK_COLLECTION]
+            # Ensure TTL index on expires_at so crashed leaders auto-release.
+            # expireAfterSeconds=0 means "expire when expires_at is in the past".
+            import asyncio as _asyncio
+            try:
+                _asyncio.get_event_loop().run_until_complete(
+                    lock_collection.create_index(
+                        "expires_at", expireAfterSeconds=0, background=True
+                    )
+                )
+            except RuntimeError:
+                # No running event loop at startup; the index is created
+                # opportunistically on the first lock attempt instead.
+                pass
+            logger.info(
+                "Distributed grace lock ENABLED (collection=%s)",
+                DEFAULT_LOCK_COLLECTION,
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade gracefully
+            logger.warning(
+                "Distributed grace lock init failed (%s: %s); "
+                "falling back to L2-cache-only",
+                type(exc).__name__,
+                exc,
+            )
+            lock_collection = None
+    else:
+        logger.info("Distributed grace lock DISABLED")
+
+    backend = SharedGraceBackend(encrypted, lock_collection=lock_collection)
     logger.info(
         "Shared grace cache backend ENABLED (collection=%s, encryption=fernet)",
         collection,

--- a/rt_grace_shared_backend.py
+++ b/rt_grace_shared_backend.py
@@ -1,0 +1,145 @@
+"""
+Shared backend for the refresh-token grace cache (Fix D of the cache plan).
+
+Fix A (refresh_token_grace_patch.py, shipped in PR #33) keeps a per-process
+LRU cache of rotated tokens for ~60s so a client retry-after-blip or
+parallel-tab refresh on the same Python process still receives the same
+new tokens. That works inside one Cloud Run replica. With
+`k8s/deployment.yaml replicas: 2`, the per-process map is invisible to
+the other replica: a refresh that lands on replica B after replica A has
+already rotated the RT still gets `Refresh token mapping not found` 401
+because B's local cache is empty AND the FastMCP RT row + JTI mapping
+were deleted by A.
+
+This module exposes a Fernet-encrypted, MongoDB-backed shared layer that
+refresh_token_grace_patch.py uses as a cross-instance L2 behind its
+in-process L1. The leader writes the rotated OAuthToken payload through
+to this shared backend after `orig_exchange` succeeds; followers on the
+same or other replicas read it back during the grace window.
+
+Reuses the same MongoDBStore + FernetEncryptionWrapper + STORAGE_ENCRYPTION_KEY
+stack that server.py already wires for OAuth state. New collection name
+defaults to `mcp-rt-grace` (the lock collection used by the optional
+Fix D.2 distributed singleflight is `mcp-rt-inflight-locks`, owned by
+this module too).
+
+Disable with BOOMI_RT_GRACE_SHARED=false (the helper returns None and the
+caller falls back to PR #33's per-process-only behavior).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger("boomi.rt_grace_shared")
+
+DEFAULT_COLLECTION = "mcp-rt-grace"
+DEFAULT_LOCK_COLLECTION = "mcp-rt-inflight-locks"
+
+
+class SharedGraceBackend:
+    """Async-safe wrapper around an AsyncKeyValue store.
+
+    Surface kept minimal: get / put / delete. The optional lock primitives
+    for Fix D.2 will be added in Phase 4.
+
+    The wrapped store is expected to encrypt at rest (production wires
+    FernetEncryptionWrapper). All exceptions on read are converted to
+    `None` (corrupted grace entry is best-effort, never a hard 401).
+    All exceptions on write are logged WARNING and swallowed (the
+    in-process L1 cache still serves the local caller).
+    """
+
+    def __init__(self, key_value_store) -> None:
+        # Deferred import so this module can be imported without the
+        # encryption stack present (tests can pass in any AsyncKeyValue).
+        from key_value.aio.errors import DecryptionError, DeserializationError
+
+        self._store = key_value_store
+        self._read_swallowed = (DecryptionError, DeserializationError)
+
+    async def get(self, key: str) -> Optional[dict[str, Any]]:
+        try:
+            return await self._store.get(key=key)
+        except self._read_swallowed as exc:
+            logger.warning(
+                "Shared grace cache read swallowed for key=%s: %s: %s",
+                key[:16] + "..." if key and len(key) > 16 else key,
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    async def put(self, key: str, value: dict[str, Any], ttl_seconds: int) -> None:
+        try:
+            await self._store.put(key=key, value=value, ttl=ttl_seconds)
+        except Exception as exc:  # noqa: BLE001 — fire-and-forget by design
+            logger.warning(
+                "GRACE_SHARED_PUT_FAILED key=%s ttl=%ds: %s: %s",
+                key[:16] + "..." if key and len(key) > 16 else key,
+                ttl_seconds,
+                type(exc).__name__,
+                exc,
+            )
+
+    async def delete(self, key: str) -> None:
+        try:
+            await self._store.delete(key=key)
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            logger.warning(
+                "Shared grace cache delete failed for key=%s: %s: %s",
+                key[:16] + "..." if key and len(key) > 16 else key,
+                type(exc).__name__,
+                exc,
+            )
+
+
+def initialize_shared_grace_backend(
+    mongodb_uri: str,
+    fernet,
+    *,
+    db_name: str = "boomi_mcp",
+) -> Optional[SharedGraceBackend]:
+    """Build the production SharedGraceBackend or return None if disabled.
+
+    Args:
+        mongodb_uri: Same URI as server.py uses for OAuth state.
+        fernet: The Fernet or MultiFernet instance built by server.py
+            (lines 424-438 today). Reusing it makes the grace cache
+            participate in the existing STORAGE_ENCRYPTION_KEY rotation.
+        db_name: Database name (default `boomi_mcp` matches OAuth state).
+
+    Returns:
+        SharedGraceBackend on success, or None when
+        BOOMI_RT_GRACE_SHARED=false (operator off-switch).
+
+    Caller-facing failures:
+        Raises ValueError if any required input is missing or empty.
+        Underlying MongoDB connection errors at first use of the returned
+        backend are caught by the backend's `put`/`get` wrappers and
+        logged WARNING — they do not crash the server.
+    """
+    if os.getenv("BOOMI_RT_GRACE_SHARED", "true").lower() in ("false", "0", "no"):
+        logger.info("Shared grace cache backend DISABLED (BOOMI_RT_GRACE_SHARED=false)")
+        return None
+    if not mongodb_uri:
+        raise ValueError("initialize_shared_grace_backend requires mongodb_uri")
+    if fernet is None:
+        raise ValueError("initialize_shared_grace_backend requires a Fernet/MultiFernet instance")
+
+    collection = os.getenv("BOOMI_RT_GRACE_SHARED_COLLECTION", DEFAULT_COLLECTION)
+
+    # Deferred imports keep this module importable in LOCAL_MODE.
+    from key_value.aio.stores.mongodb import MongoDBStore
+    from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+    mongo_store = MongoDBStore(url=mongodb_uri, db_name=db_name, coll_name=collection)
+    encrypted = FernetEncryptionWrapper(key_value=mongo_store, fernet=fernet)
+    backend = SharedGraceBackend(encrypted)
+    logger.info(
+        "Shared grace cache backend ENABLED (collection=%s, encryption=fernet)",
+        collection,
+    )
+    return backend

--- a/server.py
+++ b/server.py
@@ -383,12 +383,15 @@ if not LOCAL_MODE:
     from consent_csp_patch import apply_consent_csp_patch
     from loopback_redirect_patch import apply_loopback_redirect_patch
     from refresh_token_grace_patch import apply_refresh_token_grace_patch
+    from rt_grace_shared_backend import initialize_shared_grace_backend
     from token_cache_patch import apply_token_verifier_cache_patch
 
     apply_consent_csp_patch()
     apply_loopback_redirect_patch()
-    apply_refresh_token_grace_patch()
     apply_token_verifier_cache_patch()
+    # Note: apply_refresh_token_grace_patch is called BELOW after _fernet
+    # is built, so the (optional) shared backend can be constructed with
+    # the same MultiFernet instance used for OAuth state.
 
     # Create Google OAuth provider
     try:
@@ -453,6 +456,26 @@ if not LOCAL_MODE:
 
         print(f"[INFO] OAuth tokens will be stored in MongoDB Atlas")
         print(f"[INFO] Token storage encrypted with Fernet (write-verified)")
+
+        # Fix D: build the cross-instance shared grace backend (MongoDB +
+        # the same MultiFernet used for OAuth state). If initialization
+        # fails for any reason, log WARNING and fall back to PR #33's
+        # per-process-only grace cache rather than crashing startup.
+        shared_grace_backend = None
+        try:
+            shared_grace_backend = initialize_shared_grace_backend(
+                mongodb_uri=mongodb_uri,
+                fernet=_fernet,
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade gracefully
+            print(
+                f"[WARNING] GRACE_BACKEND_INIT_FAILED: {type(exc).__name__}: {exc} "
+                "-- falling back to per-process-only refresh-token grace"
+            )
+
+        # Apply the refresh-token grace patch now that _fernet (and thus
+        # the optional shared backend) is ready.
+        apply_refresh_token_grace_patch(shared_backend=shared_grace_backend)
 
         # Create GoogleProvider with encrypted MongoDB storage
         # Upstream v3.1.1 defaults to access_type=offline + prompt=consent

--- a/server.py
+++ b/server.py
@@ -383,10 +383,12 @@ if not LOCAL_MODE:
     from consent_csp_patch import apply_consent_csp_patch
     from loopback_redirect_patch import apply_loopback_redirect_patch
     from refresh_token_grace_patch import apply_refresh_token_grace_patch
+    from token_cache_patch import apply_token_verifier_cache_patch
 
     apply_consent_csp_patch()
     apply_loopback_redirect_patch()
     apply_refresh_token_grace_patch()
+    apply_token_verifier_cache_patch()
 
     # Create Google OAuth provider
     try:

--- a/tests/test_refresh_token_grace_patch.py
+++ b/tests/test_refresh_token_grace_patch.py
@@ -331,13 +331,23 @@ def test_singleflight_releases_slot_after_completion(monkeypatch, restore_oauth_
 
 
 class _FakeSharedBackend:
-    """In-memory stand-in for SharedGraceBackend used in unit tests."""
+    """In-memory stand-in for SharedGraceBackend used in unit tests.
 
-    def __init__(self):
+    Supports both the basic L2 cache surface (get/put/delete) and the
+    Fix D.2 lock primitives. `supports_locks` toggles whether the patch
+    enters the distributed-singleflight branch.
+    """
+
+    def __init__(self, *, supports_locks: bool = False):
         self.store: dict[str, dict] = {}
         self.put_exc: Exception | None = None
         self.get_calls = 0
         self.put_calls = 0
+        self.supports_locks = supports_locks
+        self.lock_holder: dict[str, str] = {}
+        self.claim_calls = 0
+        self.release_calls = 0
+        self.failure_marker_calls = 0
 
     async def get(self, key):
         self.get_calls += 1
@@ -351,6 +361,21 @@ class _FakeSharedBackend:
 
     async def delete(self, key):
         self.store.pop(key, None)
+
+    async def try_claim_lock(self, key, ttl_seconds, instance):
+        self.claim_calls += 1
+        if key in self.lock_holder:
+            return False
+        self.lock_holder[key] = instance
+        return True
+
+    async def release_lock(self, key):
+        self.release_calls += 1
+        self.lock_holder.pop(key, None)
+
+    async def write_failure_marker(self, key, error_type, short_ttl=5):
+        self.failure_marker_calls += 1
+        self.store[key] = {"error": error_type}
 
 
 def test_shared_backend_leader_writes_through(monkeypatch, restore_oauth_proxy):
@@ -497,3 +522,170 @@ def test_grace_cache_rejects_cross_client_replay(monkeypatch, restore_oauth_prox
     # Client B presents the same RT string -> grace cache must NOT synthesize
     out = _run(OAuthProxy.load_refresh_token(proxy, client_b, "rt-shared"))
     assert out is None
+
+
+# ---------- Fix D.2: cross-instance distributed singleflight ----------
+
+def test_d2_distributed_follower_returns_remote_leader_result(monkeypatch, restore_oauth_proxy):
+    """When this replica loses the distributed-lock race, it polls the
+    shared cache for the leader's result and returns it without calling
+    orig_exchange."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    monkeypatch.setenv("BOOMI_RT_GRACE_LOCK_POLL_MS", "20")
+    OAuthProxy = restore_oauth_proxy
+    from fastmcp.server.auth.oauth_proxy.models import _hash_token
+
+    orig_called = {"n": 0}
+
+    async def never_call(self, *args, **kwargs):
+        orig_called["n"] += 1
+        raise AssertionError("orig must not be called when remote leader produces result")
+
+    OAuthProxy.exchange_refresh_token = never_call
+
+    shared = _FakeSharedBackend(supports_locks=True)
+    # Simulate the remote leader already holding the lock.
+    shared.lock_holder[_hash_token("rt-shared")] = "remote-replica"
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+
+    async def _scenario():
+        # Schedule the "remote leader" to write the result after 50ms.
+        async def remote_leader_writes():
+            await asyncio.sleep(0.05)
+            shared.store[_hash_token("rt-shared")] = {
+                "access_token": "AT-from-remote",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "RT-from-remote",
+                "scope": "openid",
+                "client_id": "client-abc",
+                "scopes": ["openid"],
+            }
+        asyncio.create_task(remote_leader_writes())
+        return await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"])
+
+    result = _run(_scenario())
+    assert orig_called["n"] == 0
+    assert result.access_token == "AT-from-remote"
+    assert result.refresh_token == "RT-from-remote"
+
+
+def test_d2_follower_sees_failure_marker_and_raises_token_error(monkeypatch, restore_oauth_proxy):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    monkeypatch.setenv("BOOMI_RT_GRACE_LOCK_POLL_MS", "20")
+    OAuthProxy = restore_oauth_proxy
+    from fastmcp.server.auth.oauth_proxy.models import _hash_token
+    from mcp.server.auth.provider import TokenError
+
+    async def never_call(self, *args, **kwargs):
+        raise AssertionError("orig must not run on follower path")
+
+    OAuthProxy.exchange_refresh_token = never_call
+
+    shared = _FakeSharedBackend(supports_locks=True)
+    h = _hash_token("rt-shared")
+    shared.lock_holder[h] = "remote-replica"
+
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+
+    async def _scenario():
+        async def remote_leader_fails():
+            await asyncio.sleep(0.05)
+            shared.store[h] = {"error": "RuntimeError"}
+        asyncio.create_task(remote_leader_fails())
+        return await OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"])
+
+    with pytest.raises(TokenError) as excinfo:
+        _run(_scenario())
+    assert "Refresh rotation failed on peer instance" in str(excinfo.value.error_description or "")
+
+
+def test_d2_leader_holds_lock_releases_in_finally(monkeypatch, restore_oauth_proxy):
+    """The leader claims the distributed lock and releases it whether the
+    underlying exchange succeeds or fails."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from mcp.shared.auth import OAuthToken
+    from fastmcp.server.auth.oauth_proxy.models import _hash_token
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        return OAuthToken(access_token="AT", token_type="Bearer", expires_in=3600)
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    shared = _FakeSharedBackend(supports_locks=True)
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    h = _hash_token("rt-shared")
+    assert shared.claim_calls == 1
+    assert shared.release_calls == 1
+    assert h not in shared.lock_holder
+
+
+def test_d2_leader_failure_writes_marker_and_releases_lock(monkeypatch, restore_oauth_proxy):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from fastmcp.server.auth.oauth_proxy.models import _hash_token
+
+    async def fake_exchange_fails(self, client, refresh_token, scopes):
+        raise RuntimeError("upstream blew up")
+
+    OAuthProxy.exchange_refresh_token = fake_exchange_fails
+
+    shared = _FakeSharedBackend(supports_locks=True)
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    with pytest.raises(RuntimeError, match="upstream blew up"):
+        _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    h = _hash_token("rt-shared")
+    assert shared.failure_marker_calls == 1
+    assert shared.store[h] == {"error": "RuntimeError"}
+    assert shared.release_calls == 1
+    assert h not in shared.lock_holder
+
+
+def test_d2_disabled_when_backend_does_not_support_locks(monkeypatch, restore_oauth_proxy):
+    """`supports_locks=False` keeps the patch on the Phase-3 code path."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        return OAuthToken(access_token="AT", token_type="Bearer", expires_in=3600)
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    shared = _FakeSharedBackend(supports_locks=False)  # explicit
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    # Locks were NOT consulted.
+    assert shared.claim_calls == 0
+    assert shared.release_calls == 0

--- a/tests/test_refresh_token_grace_patch.py
+++ b/tests/test_refresh_token_grace_patch.py
@@ -330,6 +330,143 @@ def test_singleflight_releases_slot_after_completion(monkeypatch, restore_oauth_
     assert call_count["n"] == 2
 
 
+class _FakeSharedBackend:
+    """In-memory stand-in for SharedGraceBackend used in unit tests."""
+
+    def __init__(self):
+        self.store: dict[str, dict] = {}
+        self.put_exc: Exception | None = None
+        self.get_calls = 0
+        self.put_calls = 0
+
+    async def get(self, key):
+        self.get_calls += 1
+        return self.store.get(key)
+
+    async def put(self, key, value, ttl_seconds):
+        self.put_calls += 1
+        if self.put_exc is not None:
+            return  # real backend swallows; mirror that here
+        self.store[key] = value
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+
+
+def test_shared_backend_leader_writes_through(monkeypatch, restore_oauth_proxy):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        return OAuthToken(
+            access_token="AT-leader",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="RT-leader",
+            scope=" ".join(scopes),
+        )
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    shared = _FakeSharedBackend()
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    from fastmcp.server.auth.oauth_proxy.models import _hash_token
+    h = _hash_token("rt-shared")
+    assert h in shared.store
+    payload = shared.store[h]
+    assert payload["access_token"] == "AT-leader"
+    assert payload["refresh_token"] == "RT-leader"
+    assert payload["client_id"] == "client-abc"
+    assert payload["scopes"] == ["openid"]
+
+
+def test_shared_backend_visible_to_second_instance(monkeypatch, restore_oauth_proxy):
+    """Simulates two Cloud Run replicas sharing one Mongo-backed grace.
+
+    Verifies the cross-replica visibility property: a rotation on
+    instance A is observed by instance B's load AND exchange without
+    re-running orig_exchange. This is the property that closes the
+    multi-instance gap left over from PR #33.
+    """
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from mcp.shared.auth import OAuthToken
+
+    exchange_calls = {"n": 0}
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        exchange_calls["n"] += 1
+        return OAuthToken(
+            access_token=f"AT-{exchange_calls['n']}",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token=f"RT-{exchange_calls['n']}",
+            scope=" ".join(scopes),
+        )
+
+    async def fake_load_returning_none(self, client, refresh_token):
+        return None
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+    OAuthProxy.load_refresh_token = fake_load_returning_none
+
+    shared = _FakeSharedBackend()
+
+    # "Instance 1": apply with the shared backend.
+    mod_a = _fresh_module()
+    mod_a.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    first_result = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    # "Instance 2": re-apply with a fresh module load (= fresh local
+    # _TTLCache and inflight dict). Same shared backend.
+    mod_b = _fresh_module()
+    mod_b.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    rt_from_b = _run(OAuthProxy.load_refresh_token(proxy, client, "rt-shared"))
+    assert rt_from_b is not None
+    assert rt_from_b.client_id == "client-abc"
+
+    second_result = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+    assert exchange_calls["n"] == 1, "second instance must NOT re-call orig_exchange"
+    assert second_result.access_token == first_result.access_token
+    assert second_result.refresh_token == first_result.refresh_token
+
+
+def test_shared_backend_put_failure_does_not_break_local_exchange(monkeypatch, restore_oauth_proxy):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from mcp.shared.auth import OAuthToken
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        return OAuthToken(access_token="AT", token_type="Bearer", expires_in=3600)
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    shared = _FakeSharedBackend()
+    shared.put_exc = RuntimeError("simulated mongo outage")
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    result = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+    # Local caller still gets the OAuthToken even though shared put "failed".
+    assert result.access_token == "AT"
+
+
 def test_grace_cache_rejects_cross_client_replay(monkeypatch, restore_oauth_proxy):
     """A cached entry must only be honored for the original client_id."""
     monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")

--- a/tests/test_rt_grace_shared_backend.py
+++ b/tests/test_rt_grace_shared_backend.py
@@ -151,3 +151,70 @@ def test_initialize_missing_fernet_raises(monkeypatch):
     monkeypatch.setenv("BOOMI_RT_GRACE_SHARED", "true")
     with pytest.raises(ValueError, match="Fernet"):
         initialize_shared_grace_backend("mongodb://x", None)
+
+
+# ---------- Fix D.2 lock primitives ----------
+
+class _FakeLockCollection:
+    """In-memory motor-shaped collection used to test lock methods.
+
+    Mimics pymongo's DuplicateKeyError on insert_one for an existing _id.
+    """
+
+    def __init__(self):
+        self.docs: dict[str, dict] = {}
+        self.insert_calls = 0
+        self.delete_calls = 0
+
+    async def insert_one(self, doc):
+        self.insert_calls += 1
+        key = doc["_id"]
+        if key in self.docs:
+            from pymongo.errors import DuplicateKeyError
+            raise DuplicateKeyError("duplicate _id")
+        self.docs[key] = doc
+
+    async def delete_one(self, filt):
+        self.delete_calls += 1
+        self.docs.pop(filt["_id"], None)
+        return None
+
+
+def test_supports_locks_property():
+    backend_a = SharedGraceBackend(_StubStore())
+    assert backend_a.supports_locks is False
+    backend_b = SharedGraceBackend(_StubStore(), lock_collection=_FakeLockCollection())
+    assert backend_b.supports_locks is True
+
+
+def test_try_claim_lock_first_wins_second_loses():
+    lock_coll = _FakeLockCollection()
+    backend = SharedGraceBackend(_StubStore(), lock_collection=lock_coll)
+    first = _run(backend.try_claim_lock("k1", 30, "instance-A"))
+    second = _run(backend.try_claim_lock("k1", 30, "instance-B"))
+    assert first is True
+    assert second is False
+    assert lock_coll.docs["k1"]["instance"] == "instance-A"
+
+
+def test_release_lock_lets_next_claim_succeed():
+    lock_coll = _FakeLockCollection()
+    backend = SharedGraceBackend(_StubStore(), lock_collection=lock_coll)
+    assert _run(backend.try_claim_lock("k1", 30, "A")) is True
+    _run(backend.release_lock("k1"))
+    assert _run(backend.try_claim_lock("k1", 30, "B")) is True
+
+
+def test_try_claim_lock_raises_when_locks_unsupported():
+    backend = SharedGraceBackend(_StubStore())  # no lock_collection
+    with pytest.raises(RuntimeError, match="BOOMI_RT_GRACE_DISTRIBUTED_LOCK"):
+        _run(backend.try_claim_lock("k1", 30, "A"))
+
+
+def test_write_failure_marker_lands_in_shared_cache():
+    backing = MemoryStore()
+    wrapped = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(_new_key()))
+    backend = SharedGraceBackend(wrapped)
+    _run(backend.write_failure_marker("k1", "RuntimeError"))
+    payload = _run(backend.get("k1"))
+    assert payload == {"error": "RuntimeError"}

--- a/tests/test_rt_grace_shared_backend.py
+++ b/tests/test_rt_grace_shared_backend.py
@@ -1,0 +1,153 @@
+"""Tests for SharedGraceBackend (Fix D, shared mongo+fernet layer)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from cryptography.fernet import Fernet, MultiFernet
+from key_value.aio.errors import DecryptionError, DeserializationError
+from key_value.aio.stores.memory import MemoryStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+from rt_grace_shared_backend import SharedGraceBackend, initialize_shared_grace_backend
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _new_key() -> bytes:
+    return Fernet.generate_key()
+
+
+# ---------- core SharedGraceBackend behavior ----------
+
+def test_round_trip_via_in_memory_fernet_store():
+    backing = MemoryStore()
+    wrapped = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(_new_key()))
+    backend = SharedGraceBackend(wrapped)
+
+    payload = {"access_token": "AT-1", "refresh_token": "RT-1", "scope": "openid"}
+    _run(backend.put("k1", payload, ttl_seconds=60))
+    out = _run(backend.get("k1"))
+    assert out == payload
+
+
+def test_ttl_evicts_after_expiry():
+    backing = MemoryStore()
+    wrapped = FernetEncryptionWrapper(key_value=backing, fernet=Fernet(_new_key()))
+    backend = SharedGraceBackend(wrapped)
+
+    async def _scenario():
+        await backend.put("k1", {"x": 1}, ttl_seconds=1)
+        first = await backend.get("k1")
+        await asyncio.sleep(1.3)
+        second = await backend.get("k1")
+        return first, second
+
+    first, second = _run(_scenario())
+    assert first == {"x": 1}
+    assert second is None
+
+
+def test_two_backends_sharing_one_store_see_each_other_writes():
+    backing = MemoryStore()
+    key = _new_key()
+    backend_a = SharedGraceBackend(FernetEncryptionWrapper(key_value=backing, fernet=Fernet(key)))
+    backend_b = SharedGraceBackend(FernetEncryptionWrapper(key_value=backing, fernet=Fernet(key)))
+
+    _run(backend_a.put("shared", {"from": "A"}, ttl_seconds=60))
+    assert _run(backend_b.get("shared")) == {"from": "A"}
+
+
+def test_multifernet_can_read_old_key_ciphertext():
+    """A value written under OLD-key wrapper is readable through MultiFernet wrapper."""
+    backing = MemoryStore()
+    old_key = _new_key()
+    new_key = _new_key()
+
+    old_backend = SharedGraceBackend(
+        FernetEncryptionWrapper(key_value=backing, fernet=Fernet(old_key))
+    )
+    _run(old_backend.put("rotating", {"v": "old-era"}, ttl_seconds=60))
+
+    mf = MultiFernet([Fernet(new_key), Fernet(old_key)])
+    mf_backend = SharedGraceBackend(
+        FernetEncryptionWrapper(key_value=backing, fernet=mf)
+    )
+    assert _run(mf_backend.get("rotating")) == {"v": "old-era"}
+
+
+# ---------- failure swallowing ----------
+
+class _StubStore:
+    def __init__(self, *, get_exc=None, put_exc=None, delete_exc=None):
+        self._get_exc = get_exc
+        self._put_exc = put_exc
+        self._delete_exc = delete_exc
+
+    async def get(self, *, key):
+        if self._get_exc:
+            raise self._get_exc
+        return None
+
+    async def put(self, *, key, value, ttl):
+        if self._put_exc:
+            raise self._put_exc
+
+    async def delete(self, *, key):
+        if self._delete_exc:
+            raise self._delete_exc
+
+
+def test_get_swallows_decryption_error_returns_none(caplog):
+    backend = SharedGraceBackend(_StubStore(get_exc=DecryptionError("bad ciphertext")))
+    with caplog.at_level(logging.WARNING, logger="boomi.rt_grace_shared"):
+        out = _run(backend.get("k1"))
+    assert out is None
+    assert any("read swallowed" in rec.message for rec in caplog.records)
+
+
+def test_get_swallows_deserialization_error_returns_none(caplog):
+    backend = SharedGraceBackend(_StubStore(get_exc=DeserializationError("not a dict")))
+    with caplog.at_level(logging.WARNING, logger="boomi.rt_grace_shared"):
+        out = _run(backend.get("k1"))
+    assert out is None
+    assert any("read swallowed" in rec.message for rec in caplog.records)
+
+
+def test_get_does_not_swallow_unrelated_errors():
+    """A non-storage exception (e.g., asyncio.CancelledError) must propagate."""
+    backend = SharedGraceBackend(_StubStore(get_exc=RuntimeError("mongo down")))
+    with pytest.raises(RuntimeError, match="mongo down"):
+        _run(backend.get("k1"))
+
+
+def test_put_swallows_storage_errors_and_logs(caplog):
+    backend = SharedGraceBackend(_StubStore(put_exc=RuntimeError("mongo down")))
+    with caplog.at_level(logging.WARNING, logger="boomi.rt_grace_shared"):
+        # Must not raise — the in-process L1 cache covers the local caller
+        _run(backend.put("k1", {"x": 1}, ttl_seconds=60))
+    assert any("GRACE_SHARED_PUT_FAILED" in rec.message for rec in caplog.records)
+
+
+# ---------- initialize_shared_grace_backend ----------
+
+def test_initialize_disabled_returns_none(monkeypatch):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SHARED", "false")
+    backend = initialize_shared_grace_backend("mongodb://x", Fernet(_new_key()))
+    assert backend is None
+
+
+def test_initialize_missing_uri_raises(monkeypatch):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SHARED", "true")
+    with pytest.raises(ValueError, match="mongodb_uri"):
+        initialize_shared_grace_backend("", Fernet(_new_key()))
+
+
+def test_initialize_missing_fernet_raises(monkeypatch):
+    monkeypatch.setenv("BOOMI_RT_GRACE_SHARED", "true")
+    with pytest.raises(ValueError, match="Fernet"):
+        initialize_shared_grace_backend("mongodb://x", None)

--- a/tests/test_token_cache_patch.py
+++ b/tests/test_token_cache_patch.py
@@ -1,0 +1,299 @@
+"""Tests for the Google verifier cache patch (Fix B)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------- helpers ----------
+
+def _fresh_module():
+    sys.modules.pop("token_cache_patch", None)
+    return importlib.import_module("token_cache_patch")
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_token(label: str = "AT") -> str:
+    """Synthesize a unique token string (cache key is sha256 of this)."""
+    return f"{label}-{time.time_ns()}"
+
+
+# ---------- _TTLCache primitive ----------
+
+def test_ttlcache_hit_and_miss():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=4)
+    _run(cache.set("k1", "v1", time.time() + 60))
+    assert _run(cache.get("k1")) == "v1"
+    assert _run(cache.get("missing")) is None
+
+
+def test_ttlcache_expiry_evicts():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=4)
+    _run(cache.set("k1", "v1", time.time() - 1))
+    assert _run(cache.get("k1")) is None
+    assert "k1" not in cache._data
+
+
+def test_ttlcache_lru_evicts_at_capacity():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=2)
+    far = time.time() + 60
+    _run(cache.set("k1", "v1", far))
+    _run(cache.set("k2", "v2", far))
+    assert _run(cache.get("k1")) == "v1"  # touch k1 → MRU
+    _run(cache.set("k3", "v3", far))
+    assert _run(cache.get("k2")) is None
+    assert _run(cache.get("k1")) == "v1"
+    assert _run(cache.get("k3")) == "v3"
+
+
+def test_ttlcache_peek_remaining():
+    mod = _fresh_module()
+    cache = mod._TTLCache(max_size=4)
+    _run(cache.set("k1", "v1", time.time() + 30))
+    remaining = _run(cache.peek_remaining("k1"))
+    assert remaining is not None and 25 < remaining <= 30
+    assert _run(cache.peek_remaining("missing")) is None
+
+
+# ---------- apply_token_verifier_cache_patch ----------
+
+@pytest.fixture
+def restore_verifier():
+    """Snapshot GoogleTokenVerifier.verify_token, yield, then restore."""
+    from fastmcp.server.auth.providers.google import GoogleTokenVerifier
+    saved = GoogleTokenVerifier.verify_token
+    yield GoogleTokenVerifier
+    GoogleTokenVerifier.verify_token = saved
+
+
+def test_disabled_via_env_is_noop(monkeypatch, restore_verifier):
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "true")
+    GoogleTokenVerifier = restore_verifier
+    pre = GoogleTokenVerifier.verify_token
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+    assert GoogleTokenVerifier.verify_token is pre
+
+
+def test_cache_serves_repeat_calls_for_same_token(monkeypatch, restore_verifier):
+    """5 sequential calls with the same token → original invoked once."""
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "false")
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_TTL_SECONDS", "300")
+    GoogleTokenVerifier = restore_verifier
+
+    call_count = {"n": 0}
+    from fastmcp.server.auth.auth import AccessToken
+
+    async def stubbed(self, token):
+        call_count["n"] += 1
+        return AccessToken(
+            token=token,
+            client_id="cid",
+            scopes=["openid"],
+            expires_at=int(time.time() + 60),
+            claims={"sub": "user-1"},
+        )
+
+    GoogleTokenVerifier.verify_token = stubbed
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+
+    verifier = SimpleNamespace()
+    tok = _make_token()
+
+    async def _run_many():
+        return [await GoogleTokenVerifier.verify_token(verifier, tok) for _ in range(5)]
+
+    results = _run(_run_many())
+    assert call_count["n"] == 1
+    assert all(r.token == tok for r in results)
+    assert all(r.claims["sub"] == "user-1" for r in results)
+
+
+def test_negative_results_not_cached(monkeypatch, restore_verifier):
+    """Stubbed verify_token returning None: every call invokes the original."""
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "false")
+    GoogleTokenVerifier = restore_verifier
+
+    call_count = {"n": 0}
+
+    async def stubbed_none(self, token):
+        call_count["n"] += 1
+        return None
+
+    GoogleTokenVerifier.verify_token = stubbed_none
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+
+    verifier = SimpleNamespace()
+    tok = _make_token()
+
+    async def _run_many():
+        return [await GoogleTokenVerifier.verify_token(verifier, tok) for _ in range(5)]
+
+    results = _run(_run_many())
+    assert call_count["n"] == 5
+    assert all(r is None for r in results)
+
+
+def test_ttl_cap_overrides_long_token_lifetime(monkeypatch, restore_verifier):
+    """expires_at=now+3600 with cap=1: cache entry evicts at the cap."""
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "false")
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_TTL_SECONDS", "1")
+    GoogleTokenVerifier = restore_verifier
+
+    call_count = {"n": 0}
+    from fastmcp.server.auth.auth import AccessToken
+
+    async def stubbed(self, token):
+        call_count["n"] += 1
+        return AccessToken(
+            token=token,
+            client_id="cid",
+            scopes=["openid"],
+            expires_at=int(time.time() + 3600),  # long lifetime
+            claims={},
+        )
+
+    GoogleTokenVerifier.verify_token = stubbed
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+
+    verifier = SimpleNamespace()
+    tok = _make_token()
+
+    async def _scenario():
+        await GoogleTokenVerifier.verify_token(verifier, tok)  # n=1
+        await GoogleTokenVerifier.verify_token(verifier, tok)  # cache hit
+        await asyncio.sleep(1.2)  # exceed the 1s TTL cap
+        await GoogleTokenVerifier.verify_token(verifier, tok)  # n=2
+
+    _run(_scenario())
+    assert call_count["n"] == 2
+
+
+def test_different_tokens_do_not_collide(monkeypatch, restore_verifier):
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "false")
+    GoogleTokenVerifier = restore_verifier
+
+    call_log: list[str] = []
+    from fastmcp.server.auth.auth import AccessToken
+
+    async def stubbed(self, token):
+        call_log.append(token)
+        return AccessToken(
+            token=token, client_id="cid", scopes=["openid"],
+            expires_at=int(time.time() + 60), claims={},
+        )
+
+    GoogleTokenVerifier.verify_token = stubbed
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+
+    verifier = SimpleNamespace()
+    tok_a, tok_b = _make_token("A"), _make_token("B")
+
+    async def _scenario():
+        await GoogleTokenVerifier.verify_token(verifier, tok_a)
+        await GoogleTokenVerifier.verify_token(verifier, tok_b)
+        await GoogleTokenVerifier.verify_token(verifier, tok_a)  # cache hit
+        await GoogleTokenVerifier.verify_token(verifier, tok_b)  # cache hit
+
+    _run(_scenario())
+    assert call_log == [tok_a, tok_b]
+
+
+def test_cache_key_is_sha256_prefix(monkeypatch, restore_verifier):
+    """The stored cache key never contains the plaintext token."""
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "false")
+    GoogleTokenVerifier = restore_verifier
+
+    from fastmcp.server.auth.auth import AccessToken
+
+    async def stubbed(self, token):
+        return AccessToken(
+            token=token, client_id="cid", scopes=["openid"],
+            expires_at=int(time.time() + 60), claims={},
+        )
+
+    GoogleTokenVerifier.verify_token = stubbed
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+
+    # Grab the closure's cache reference via the patched function
+    patched_fn = GoogleTokenVerifier.verify_token
+    closure_vars = {
+        cell_name: cell.cell_contents
+        for cell_name, cell in zip(patched_fn.__code__.co_freevars, patched_fn.__closure__)
+    }
+    cache = closure_vars["cache"]
+
+    verifier = SimpleNamespace()
+    plaintext_token = "MY-SECRET-TOKEN-PLAINTEXT"
+
+    _run(GoogleTokenVerifier.verify_token(verifier, plaintext_token))
+
+    cache_keys = list(cache._data.keys())
+    assert plaintext_token not in cache_keys
+    assert all(len(k) == 32 for k in cache_keys)  # sha256 prefix length
+
+
+def test_swr_returns_stale_and_triggers_background_refresh(monkeypatch, restore_verifier):
+    """With SWR enabled, an entry inside the SWR window returns immediately
+    and schedules a background refresh."""
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_DISABLE", "false")
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_SWR", "true")
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_SWR_WINDOW", "60")  # always within window
+    monkeypatch.setenv("BOOMI_TOKEN_CACHE_TTL_SECONDS", "50")
+    GoogleTokenVerifier = restore_verifier
+
+    call_count = {"n": 0}
+    from fastmcp.server.auth.auth import AccessToken
+
+    async def stubbed(self, token):
+        call_count["n"] += 1
+        return AccessToken(
+            token=token, client_id="cid", scopes=["openid"],
+            expires_at=int(time.time() + 50), claims={"call": call_count["n"]},
+        )
+
+    GoogleTokenVerifier.verify_token = stubbed
+
+    mod = _fresh_module()
+    mod.apply_token_verifier_cache_patch()
+
+    verifier = SimpleNamespace()
+    tok = _make_token()
+
+    async def _scenario():
+        first = await GoogleTokenVerifier.verify_token(verifier, tok)  # n=1, cache
+        # Subsequent call: hit (returns stale immediately) + schedules refresh
+        second = await GoogleTokenVerifier.verify_token(verifier, tok)
+        # Let the background task run
+        await asyncio.sleep(0.05)
+        return first, second
+
+    first, second = _run(_scenario())
+    # The second call returned the cached value (call=1) BEFORE the refresh
+    # completed, but the background refresh fired (call_count went to 2).
+    assert first.claims["call"] == 1
+    assert second.claims["call"] == 1  # stale-while-revalidate
+    assert call_count["n"] == 2  # background refresh ran

--- a/token_cache_patch.py
+++ b/token_cache_patch.py
@@ -1,0 +1,167 @@
+"""
+Per-process LRU TTL cache for GoogleTokenVerifier.verify_token (Fix B).
+
+Every MCP tool call goes through OAuthProxy.load_access_token, which calls
+GoogleTokenVerifier.verify_token (fastmcp/server/auth/providers/google.py
+lines 67-156). That method issues two synchronous HTTP requests to Google
+on every invocation:
+  GET https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=...
+  GET https://www.googleapis.com/oauth2/v2/userinfo
+
+Consequences without this cache:
+  - ~150-400 ms latency tax on every MCP tool call.
+  - Google rate-limits both endpoints per OAuth client and per source IP.
+    A burst trips the limit; every tool call then 401s because
+    GoogleTokenVerifier returns None on HTTPX errors (google.py:160-162)
+    and OAuthProxy.load_access_token silently turns None into a 401
+    (proxy.py:1452-1454) with no log line.
+
+This patch wraps verify_token with a bounded LRU TTL cache keyed by
+sha256(token)[:32]. Cached AccessToken instances are returned for the
+remainder of their declared expiry, capped at BOOMI_TOKEN_CACHE_TTL_SECONDS
+(default 300 s -- caps the window in which Google-side revocation is not
+honored). Negative results (None) are NEVER cached: a transient Google
+rate-limit must not lock a user out for the TTL.
+
+Disable with BOOMI_TOKEN_CACHE_DISABLE=true. Capacity bounded by
+BOOMI_TOKEN_CACHE_MAX_SIZE (default 256).
+
+Stale-while-revalidate (opt-in, BOOMI_TOKEN_CACHE_SWR=true): when a hit's
+remaining TTL drops below BOOMI_TOKEN_CACHE_SWR_WINDOW (default 30 s),
+return the cached value immediately and schedule an asyncio.create_task
+background refresh. Defends against short Google outages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import time
+from collections import OrderedDict
+from typing import Any
+
+logger = logging.getLogger("boomi.token_cache")
+
+
+class _TTLCache:
+    """Bounded LRU dict with per-entry expiry. Single asyncio.Lock; O(1)."""
+
+    def __init__(self, max_size: int) -> None:
+        self._data: "OrderedDict[str, tuple[float, Any]]" = OrderedDict()
+        self._max_size = max_size
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> Any | None:
+        async with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return None
+            expires_at, value = entry
+            if expires_at <= time.time():
+                self._data.pop(key, None)
+                return None
+            self._data.move_to_end(key)
+            return value
+
+    async def peek_remaining(self, key: str) -> float | None:
+        """Return remaining seconds for an entry, or None if missing/expired.
+
+        Does not mutate LRU order. Used by the SWR refresh-trigger check.
+        """
+        async with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return None
+            expires_at, _ = entry
+            remaining = expires_at - time.time()
+            return remaining if remaining > 0 else None
+
+    async def set(self, key: str, value: Any, expires_at: float) -> None:
+        async with self._lock:
+            self._data[key] = (expires_at, value)
+            self._data.move_to_end(key)
+            while len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+
+
+def apply_token_verifier_cache_patch() -> None:
+    """Install the verifier cache monkey-patch on GoogleTokenVerifier.
+
+    Idempotent at import time: applying twice overwrites the same method
+    with a functionally identical wrapper, re-creating the cache (no live
+    tokens at startup).
+    """
+    if os.getenv("BOOMI_TOKEN_CACHE_DISABLE", "").lower() in ("true", "1", "yes"):
+        logger.info("Token verifier cache DISABLED (BOOMI_TOKEN_CACHE_DISABLE)")
+        return
+
+    ttl_cap = int(os.getenv("BOOMI_TOKEN_CACHE_TTL_SECONDS", "300"))
+    max_size = int(os.getenv("BOOMI_TOKEN_CACHE_MAX_SIZE", "256"))
+    swr_enabled = os.getenv("BOOMI_TOKEN_CACHE_SWR", "").lower() in ("true", "1", "yes")
+    swr_window = int(os.getenv("BOOMI_TOKEN_CACHE_SWR_WINDOW", "30"))
+
+    cache = _TTLCache(max_size=max_size)
+
+    # Track in-flight SWR refreshes so a slow Google response doesn't
+    # spawn one new task per request during the SWR window.
+    swr_inflight: set[str] = set()
+
+    # Imports are deferred so this module can be imported in LOCAL_MODE
+    # without pulling in the FastMCP auth stack.
+    from fastmcp.server.auth.providers.google import GoogleTokenVerifier
+
+    original_verify_token = GoogleTokenVerifier.verify_token
+
+    def _cache_ttl(result_expires_at: float | None) -> float:
+        """Compute TTL = min(token's remaining lifetime, ttl_cap)."""
+        if not result_expires_at:
+            return float(ttl_cap)
+        return min(float(result_expires_at) - time.time(), float(ttl_cap))
+
+    async def _refresh_in_background(self, token: str, key: str) -> None:
+        """SWR: re-run verify_token and update the cache; never raise."""
+        try:
+            result = await original_verify_token(self, token)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("SWR background refresh raised: %s", exc)
+            return
+        finally:
+            swr_inflight.discard(key)
+        if result is None:
+            # Negative result: leave the existing cache entry alone; the
+            # original 401 path will trigger on the next hit AFTER the
+            # existing entry expires naturally. Do not poison the cache.
+            return
+        ttl = _cache_ttl(getattr(result, "expires_at", None))
+        if ttl > 0:
+            await cache.set(key, result, time.time() + ttl)
+
+    async def cached_verify_token(self, token: str):
+        key = hashlib.sha256(token.encode("utf-8")).hexdigest()[:32]
+        hit = await cache.get(key)
+        if hit is not None:
+            if swr_enabled:
+                remaining = await cache.peek_remaining(key)
+                if remaining is not None and remaining < swr_window and key not in swr_inflight:
+                    swr_inflight.add(key)
+                    asyncio.create_task(_refresh_in_background(self, token, key))
+            return hit
+        logger.debug("Token cache MISS key=%s...", key[:8])
+        result = await original_verify_token(self, token)
+        if result is None:
+            # Negative result: never cache.
+            return None
+        ttl = _cache_ttl(getattr(result, "expires_at", None))
+        if ttl > 0:
+            await cache.set(key, result, time.time() + ttl)
+        return result
+
+    GoogleTokenVerifier.verify_token = cached_verify_token
+    logger.info(
+        "Token verifier cache ENABLED (ttl_cap=%ds, max_size=%d, swr=%s)",
+        ttl_cap,
+        max_size,
+        "on" if swr_enabled else "off",
+    )


### PR DESCRIPTION
## Summary

Implements `docs/plans/oauth_token_verifier_cache_plan.json` — closes the two cache-shaped gaps PR #33 left open in the OAuth path:

- **Fix B — Per-process Google verifier cache.** Wraps `GoogleTokenVerifier.verify_token` with an in-house LRU TTL cache so a burst of MCP tool calls from one authed session triggers exactly 1 Google `tokeninfo`+`userinfo` round trip per cache TTL instead of 2 per tool call. Negative results are never cached (transient Google rate-limits do not lock users out). Optional SWR (`BOOMI_TOKEN_CACHE_SWR=true`) serves stale within the window and refreshes in the background. Eliminates root cause #2 from the original investigation.

- **Fix D — Cross-instance refresh-token grace cache (MongoDB-backed).** New `rt_grace_shared_backend.py` adds a `SharedGraceBackend` over `MongoDBStore` + `FernetEncryptionWrapper` reusing the same `STORAGE_ENCRYPTION_KEY` (MultiFernet-aware) as the rest of OAuth state. `apply_refresh_token_grace_patch` now accepts `shared_backend=None` (default keeps PR #33 behavior); when provided, the leader writes through after `orig_exchange`, and load/exchange consult the shared backend on local cache miss. Closes the multi-instance `Refresh token mapping not found` 401 that the per-process grace cache alone couldn't prevent under `replicas: 2`.

- **Fix D.2 (opt-in, off by default) — Distributed singleflight.** `SharedGraceBackend.try_claim_lock`/`release_lock`/`write_failure_marker` against a new `mcp-rt-inflight-locks` collection with a TTL index. The leader claims; the loser becomes a remote-follower and polls the shared cache for the result. Failure marker propagation surfaces the leader's `TokenError` to followers within ~5s instead of waiting full lock TTL. Enable via `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true` only if Phase-2 logs show residual cross-replica races.

**No new infra.** Reuses `MONGODB_URI` + `STORAGE_ENCRYPTION_KEY`. New collections (`mcp-rt-grace`, `mcp-rt-inflight-locks`) auto-evict via TTL.

## Diff

```
.env.example                            |  27 +++
README.md                               |  32 ++++
docs/oauth-migration-runbook.md         |  79 ++++++++
refresh_token_grace_patch.py            | 240 +++++++++++++++++++++--
rt_grace_shared_backend.py              | 267 ++++++++++++++++++++++++++ (new)
server.py                               |  27 ++-
tests/test_refresh_token_grace_patch.py | 329 ++++++++++++++++++++++++++++++++
tests/test_rt_grace_shared_backend.py   | 220 +++++++++++++++++++++ (new)
tests/test_token_cache_patch.py         | 299 +++++++++++++++++++++++++++++ (new)
token_cache_patch.py                    | 167 ++++++++++++++++ (new)
```

5 commits, 1666 insertions / 21 deletions. Phases independent, each commit ships one logical unit.

## Test plan

- [x] Local pytest: **338 passed** (303 → +35 from new cache + shared backend + lock suites)
- [x] Targeted suites:
  - `tests/test_token_cache_patch.py` — 11 tests (LRU primitives, hit/miss/expiry, TTL cap, sha256 key safety, SWR background refresh)
  - `tests/test_rt_grace_shared_backend.py` — 16 tests (in-memory MultiFernet round-trip, write-swallow on storage errors, read-swallow on Decryption/DeserializationError, lock primitives, failure markers)
  - `tests/test_refresh_token_grace_patch.py` — 20 tests (PR-33 singleflight scenarios + 3 shared-backend tests + 5 Fix D.2 lock tests)
- [x] `boomi-qa-tester` QA pass: clean. `import server`, both new modules, the kwarg-equivalent grace patch invocation, and read-only `.fn()` calls (`list_capabilities`, `list_boomi_profiles`, `manage_folders`) all work in LOCAL_MODE. Two pre-existing bugs flagged (`list_capabilities` `_tool_manager` private-API issue and `manage_folders` 403 on dev creds) — both reproduce on `beea18d` (PR #33 baseline) and are NOT regressions.

### Post-merge live smoke (separate from this PR)

- **Fix B**: 5 MCP tool calls from one authed session → Cloud Run logs show exactly 1 "Token cache MISS" DEBUG line; network logs show 1 `tokeninfo` + 1 `userinfo` request (vs 5+5 before).
- **Fix D**: 2 concurrent `curl -d grant_type=refresh_token -d refresh_token=<same RT>` from different network paths → both 200 with identical `access_token`/`refresh_token`; `mcp-rt-grace` collection has one entry; diagnostic logs show `Refresh-token grace SHARED HIT` from the replica that did not perform the original rotation.
- **Fix D negative**: 70 s later with the same RT → 401 `invalid_grant`.
- **Fix D.2** (only after enabling `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true`): `mcp-rt-inflight-locks` rows appear briefly during concurrent rotations; logs show `DISTRIBUTED FOLLOWER` lines.

## Rollback

Per-fix off-switches (all defaults inside CLAUDE.md-compliant safe values):

| Fix | Off-switch |
|---|---|
| B — verifier cache | `BOOMI_TOKEN_CACHE_DISABLE=true` |
| D — shared grace cache | `BOOMI_RT_GRACE_SHARED=false` |
| D.2 — distributed lock | `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=false` (default) |

Full rollback: `git revert <merge_commit>`. The two new MongoDB collections auto-evict via TTL; explicit cleanup optional.

Companion plan: `docs/plans/oauth_token_verifier_cache_plan.json`.