### PR TITLE
enable fix d in prod + boomi.* logger visibility + shared-cache read degradation

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -111,7 +111,7 @@ steps:
           --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID \
           --region=$_DEPLOY_REGION \
           --memory=2Gi \
-          --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$$TAG" \
+          --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$$TAG,BOOMI_RT_GRACE_SHARED=true" \
           --quiet
 
 images:

--- a/docs/oauth-migration-runbook.md
+++ b/docs/oauth-migration-runbook.md
@@ -386,3 +386,70 @@ corruption, a botched rotation, or a regression in the storage stack
 worth investigating. The alert's 300 s / >3 threshold is the
 *circuit-breaker* tier, not the *SLO* tier; long-term zero is the
 real target.
+
+## Production enablement of cross-instance grace + logging visibility (2026-05-18, third pass)
+
+### Why
+
+The first-pass cache hardening (PR #34) added the cross-instance
+shared grace cache and the per-process Google verifier cache, but
+`BOOMI_RT_GRACE_SHARED` was never wired on the Cloud Run service —
+so Fix D shipped dormant. Additionally, the four hardening patches
+(`refresh_token_grace_patch`, `token_cache_patch`,
+`storage_healing_patch`, `rt_grace_shared_backend`) log under the
+`boomi.*` logger tree, which inherited Python's default WARNING
+level — their `INFO` boot lines were silently dropped, so operators
+had no log-based way to confirm what was running.
+
+This pass pins `BOOMI_RT_GRACE_SHARED=true` in both `cloudbuild.yaml`
+and `k8s/deployment.yaml`, and adds a scoped `boomi.*` stderr handler
+at INFO in `server.py` so the patches' boot lines reach Cloud Logging
+without flooding it with third-party chatter. Shared-cache read
+failures degrade to the local exchange path (no hard 401 on Mongo
+outage), making "on by default" safe.
+
+### One-shot enable on a running revision
+
+If you want Fix D on **before** the next Cloud Build deploy completes:
+
+```bash
+gcloud run services update boomi-mcp-server \
+  --region us-central1 --project boomimcp \
+  --update-env-vars BOOMI_RT_GRACE_SHARED=true
+```
+
+`--update-env-vars` is additive — other env vars (`MONGODB_URI`,
+`OIDC_CLIENT_*`, `STORAGE_ENCRYPTION_KEY`, etc.) are preserved.
+
+### Expected boot log lines
+
+After the new revision rolls out, you should see one of each per
+replica during boot (filter substring → expected line):
+
+| Filter substring | Source | Expected |
+|---|---|---|
+| `Token verifier cache ENABLED` | `token_cache_patch` | Always (Fix B is on by default) |
+| `Refresh-token grace window ENABLED` | `refresh_token_grace_patch` | Always (Fix A is on by default) |
+| `Shared grace cache backend ENABLED` | `rt_grace_shared_backend` | Only after Fix 1 pinning |
+| `Distributed grace lock ENABLED` | `rt_grace_shared_backend` | Only after Fix 1 pinning |
+
+Tail a single boot:
+
+```bash
+gcloud logging read 'resource.type="cloud_run_revision"
+  AND resource.labels.service_name="boomi-mcp-server"
+  AND (textPayload:"Shared grace cache backend ENABLED"
+    OR textPayload:"Distributed grace lock ENABLED"
+    OR textPayload:"Refresh-token grace window ENABLED"
+    OR textPayload:"Token verifier cache ENABLED")' \
+  --project boomimcp --freshness=1h --limit 10 --order=asc
+```
+
+### Rollback
+
+Per-fix off-switches: set `BOOMI_RT_GRACE_SHARED=false` (or
+`--remove-env-vars BOOMI_RT_GRACE_SHARED`) to drop back to
+per-process-only grace. The local grace + singleflight from PR #33
+still protects each replica individually. The logging change is
+pure observability — revert by removing the `_boomi_log` block at
+the top of `server.py`.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -126,6 +126,15 @@ spec:
         - name: BOOMI_OAUTH_DIAGNOSTICS
           value: "true"
 
+        # Cross-instance shared refresh-token grace cache (Fix D from
+        # PR #34). Defaults to off in the patch; we pin it on here so
+        # multi-replica refresh rotations share the grace window via
+        # Mongo and survive race conditions across pods. Shared reads
+        # degrade to local exchange on Mongo outage (no hard 401), so
+        # turning this on is safe even with intermittent Mongo issues.
+        - name: BOOMI_RT_GRACE_SHARED
+          value: "true"
+
         # Boomi Docs Knowledge Base (optional retrieval layer)
         - name: BOOMI_DOCS_ENABLED
           valueFrom:

--- a/refresh_token_grace_patch.py
+++ b/refresh_token_grace_patch.py
@@ -154,7 +154,16 @@ def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
         """
         if shared_backend is None:
             return None
-        payload = await shared_backend.get(old_hash)
+        try:
+            payload = await shared_backend.get(old_hash)
+        except Exception as exc:  # noqa: BLE001 — shared cache is best-effort
+            logger.warning(
+                "Refresh-token grace shared get failed for key=%s: %s: %s",
+                old_hash[:16] + "..." if old_hash and len(old_hash) > 16 else old_hash,
+                type(exc).__name__,
+                exc,
+            )
+            return None
         if not payload or "access_token" not in payload:
             return None
         return _deserialize(payload)
@@ -172,7 +181,16 @@ def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
         from mcp.server.auth.provider import TokenError
         deadline = time.time() + max_wait_seconds
         while time.time() < deadline:
-            payload = await shared_backend.get(old_hash) if shared_backend else None
+            try:
+                payload = await shared_backend.get(old_hash) if shared_backend else None
+            except Exception as exc:  # noqa: BLE001 — degrade to local fallback
+                logger.warning(
+                    "Refresh-token grace shared poll failed for key=%s: %s: %s",
+                    old_hash[:16] + "..." if old_hash and len(old_hash) > 16 else old_hash,
+                    type(exc).__name__,
+                    exc,
+                )
+                payload = None
             if payload:
                 if "error" in payload:
                     raise TokenError(

--- a/rt_grace_shared_backend.py
+++ b/rt_grace_shared_backend.py
@@ -46,10 +46,11 @@ class SharedGraceBackend:
     lock primitives for Fix D.2 (cross-instance singleflight).
 
     The wrapped store is expected to encrypt at rest (production wires
-    FernetEncryptionWrapper). All exceptions on read are converted to
-    `None` (corrupted grace entry is best-effort, never a hard 401).
-    All exceptions on write are logged WARNING and swallowed (the
-    in-process L1 cache still serves the local caller).
+    FernetEncryptionWrapper). Store failures on read are converted to
+    `None` (corrupted/unavailable grace entry is best-effort, never a hard
+    401). Task cancellation is still allowed to propagate. All exceptions
+    on write are logged WARNING and swallowed (the in-process L1 cache still
+    serves the local caller).
 
     The optional `lock_collection` argument is a motor collection (raw
     MongoDB client) used by `try_claim_lock`/`release_lock` for atomic
@@ -77,6 +78,14 @@ class SharedGraceBackend:
         except self._read_swallowed as exc:
             logger.warning(
                 "Shared grace cache read swallowed for key=%s: %s: %s",
+                key[:16] + "..." if key and len(key) > 16 else key,
+                type(exc).__name__,
+                exc,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 — best-effort cache read
+            logger.warning(
+                "GRACE_SHARED_GET_FAILED key=%s: %s: %s",
                 key[:16] + "..." if key and len(key) > 16 else key,
                 type(exc).__name__,
                 exc,

--- a/server.py
+++ b/server.py
@@ -16,11 +16,27 @@ When BOOMI_LOCAL is not set (production):
 """
 
 import json
+import logging
 import os
 import sys
 from enum import Enum
 from typing import Dict
 from pathlib import Path
+
+# Wire the `boomi.*` logger tree to stderr at INFO so the
+# refresh-token/cache/storage-healing patches' boot + runtime lines reach
+# Cloud Logging. Scoped to "boomi" only so uvicorn/fastmcp/motor INFO
+# chatter stays at their defaults. Done BEFORE importing any patch
+# module since each calls `logging.getLogger("boomi.<area>")` at import.
+# We deliberately leave propagate at its default (True) so pytest's caplog
+# (which attaches to root) still captures records — our own handler runs
+# first, and root has no configured handler so there's no double-emit.
+_boomi_log = logging.getLogger("boomi")
+if not _boomi_log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("[%(levelname)s] [%(name)s] %(message)s"))
+    _boomi_log.addHandler(_h)
+    _boomi_log.setLevel(logging.INFO)
 
 from fastmcp import FastMCP
 

--- a/tests/test_refresh_token_grace_patch.py
+++ b/tests/test_refresh_token_grace_patch.py
@@ -340,6 +340,7 @@ class _FakeSharedBackend:
 
     def __init__(self, *, supports_locks: bool = False):
         self.store: dict[str, dict] = {}
+        self.get_exc: Exception | None = None
         self.put_exc: Exception | None = None
         self.get_calls = 0
         self.put_calls = 0
@@ -351,6 +352,8 @@ class _FakeSharedBackend:
 
     async def get(self, key):
         self.get_calls += 1
+        if self.get_exc is not None:
+            raise self.get_exc
         return self.store.get(key)
 
     async def put(self, key, value, ttl_seconds):
@@ -490,6 +493,34 @@ def test_shared_backend_put_failure_does_not_break_local_exchange(monkeypatch, r
     result = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
     # Local caller still gets the OAuthToken even though shared put "failed".
     assert result.access_token == "AT"
+
+
+def test_shared_backend_get_failure_does_not_break_local_exchange(monkeypatch, restore_oauth_proxy):
+    """A shared-cache read outage must degrade to the normal local exchange."""
+    monkeypatch.setenv("BOOMI_RT_GRACE_SECONDS", "60")
+    OAuthProxy = restore_oauth_proxy
+    from mcp.shared.auth import OAuthToken
+
+    call_count = {"n": 0}
+
+    async def fake_exchange(self, client, refresh_token, scopes):
+        call_count["n"] += 1
+        return OAuthToken(access_token="AT-local", token_type="Bearer", expires_in=3600)
+
+    OAuthProxy.exchange_refresh_token = fake_exchange
+
+    shared = _FakeSharedBackend()
+    shared.get_exc = RuntimeError("simulated mongo read outage")
+    mod = _fresh_module()
+    mod.apply_refresh_token_grace_patch(shared_backend=shared)
+
+    proxy = SimpleNamespace()
+    client = SimpleNamespace(client_id="client-abc")
+    rt = SimpleNamespace(token="rt-shared")
+    result = _run(OAuthProxy.exchange_refresh_token(proxy, client, rt, ["openid"]))
+
+    assert call_count["n"] == 1
+    assert result.access_token == "AT-local"
 
 
 def test_grace_cache_rejects_cross_client_replay(monkeypatch, restore_oauth_proxy):

--- a/tests/test_rt_grace_shared_backend.py
+++ b/tests/test_rt_grace_shared_backend.py
@@ -118,10 +118,18 @@ def test_get_swallows_deserialization_error_returns_none(caplog):
     assert any("read swallowed" in rec.message for rec in caplog.records)
 
 
-def test_get_does_not_swallow_unrelated_errors():
-    """A non-storage exception (e.g., asyncio.CancelledError) must propagate."""
+def test_get_swallows_runtime_storage_errors_returns_none(caplog):
     backend = SharedGraceBackend(_StubStore(get_exc=RuntimeError("mongo down")))
-    with pytest.raises(RuntimeError, match="mongo down"):
+    with caplog.at_level(logging.WARNING, logger="boomi.rt_grace_shared"):
+        out = _run(backend.get("k1"))
+    assert out is None
+    assert any("GRACE_SHARED_GET_FAILED" in rec.message for rec in caplog.records)
+
+
+def test_get_does_not_swallow_cancelled_error():
+    """Task cancellation is control flow, not a storage cache miss."""
+    backend = SharedGraceBackend(_StubStore(get_exc=asyncio.CancelledError()))
+    with pytest.raises(asyncio.CancelledError):
         _run(backend.get("k1"))
 
 


### PR DESCRIPTION
## Summary

Closes the two code/config gaps surfaced by the /goal OAuth-refresh verification on `main`, plus bundles in the user's just-shipped shared-cache-read resiliency work so all three ship together.

- **Fix 1 — enable Fix D in prod.** PR #34 added `SharedGraceBackend` for cross-instance refresh-token grace but never wired `BOOMI_RT_GRACE_SHARED=true` on the Cloud Run service. This PR pins it in `cloudbuild.yaml` (`--update-env-vars`) and `k8s/deployment.yaml` so every deploy boots with the cross-instance grace cache active. Distributed lock defaults to on with the shared backend, so D.2 comes along automatically.
- **Fix 2 — boomi.* logger visibility.** The patches use `logging.getLogger("boomi.<area>")` but `server.py` never configures Python logging, so their INFO boot lines were silently dropped (root stays at default WARNING). This PR adds a 9-line scoped `boomi` StreamHandler at INFO in `server.py` before any patch is imported. Scoped to `boomi` only — uvicorn/fastmcp/motor INFO chatter stays at their defaults. Propagate left at default True so pytest's `caplog` still captures records.
- **Fix 3 — shared-cache read degradation.** Wraps `shared_backend.get(...)` calls in try/except in `refresh_token_grace_patch.py:148` and `:181`, plus adds a generic `except Exception` branch in `rt_grace_shared_backend.py:75` so Mongo read outages degrade to the local exchange path instead of bubbling up as 401s. `asyncio.CancelledError` still propagates (it subclasses `BaseException`, not `Exception`). With this in place, enabling Fix D is safe even with intermittent Mongo issues.

## Test plan

- [x] Full pytest suite: 362 passed (was 360; +2 from Fix 3's new tests)
- [x] Logger smoke test: INFO emits once, DEBUG does not emit, WARNING emits exactly once (no double-emit via root lastResort)
- [x] `boomi-qa-tester` agent live `.fn()` calls on the branch: all 6 tools execute cleanly, patches import without error, no new regressions
- [ ] After merge: Cloud Build deploys new revision; tail logs for `Shared grace cache backend ENABLED` + `Distributed grace lock ENABLED` per replica
- [ ] After merge: confirm Mongo collections `mcp-rt-grace` and `mcp-rt-inflight-locks` auto-create after a few refreshes

## Rollback

Per-fix off-switches in the runbook. Fix 1: `gcloud run services update --remove-env-vars BOOMI_RT_GRACE_SHARED`. Fix 2: pure observability rollback. Fix 3: revert the commit (local grace + singleflight still protect single replica).

See `docs/oauth-migration-runbook.md` for the operator-facing notes.