### PR TITLE
address codex findings on PR #36: handler level, fix d.2 pinning, rollback docs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -111,7 +111,7 @@ steps:
           --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID \
           --region=$_DEPLOY_REGION \
           --memory=2Gi \
-          --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$$TAG,BOOMI_RT_GRACE_SHARED=true" \
+          --update-env-vars="BOOMI_DOCS_ENABLED=true,BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db,BOOMI_DOCS_RELEASE_TAG=$$TAG,BOOMI_RT_GRACE_SHARED=true,BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true" \
           --quiet
 
 images:

--- a/docs/oauth-migration-runbook.md
+++ b/docs/oauth-migration-runbook.md
@@ -392,30 +392,47 @@ real target.
 ### Why
 
 The first-pass cache hardening (PR #34) added the cross-instance
-shared grace cache and the per-process Google verifier cache, but
-`BOOMI_RT_GRACE_SHARED` was never wired on the Cloud Run service —
-so Fix D shipped dormant. Additionally, the four hardening patches
-(`refresh_token_grace_patch`, `token_cache_patch`,
-`storage_healing_patch`, `rt_grace_shared_backend`) log under the
-`boomi.*` logger tree, which inherited Python's default WARNING
-level — their `INFO` boot lines were silently dropped, so operators
-had no log-based way to confirm what was running.
+shared grace cache and the per-process Google verifier cache.
+`BOOMI_RT_GRACE_SHARED` defaults to `true` in
+`rt_grace_shared_backend.initialize_shared_grace_backend`, so Fix D
+has actually been active in production since PR #34 — but
+`BOOMI_RT_GRACE_DISTRIBUTED_LOCK` defaults to `false`, so the
+Fix D.2 singleflight was off, and the four hardening patches log
+under the `boomi.*` logger tree, which inherited Python's default
+WARNING level — their `INFO` boot lines were silently dropped, so
+operators had no log-based way to confirm what was running.
 
-This pass pins `BOOMI_RT_GRACE_SHARED=true` in both `cloudbuild.yaml`
-and `k8s/deployment.yaml`, and adds a scoped `boomi.*` stderr handler
-at INFO in `server.py` so the patches' boot lines reach Cloud Logging
-without flooding it with third-party chatter. Shared-cache read
-failures degrade to the local exchange path (no hard 401 on Mongo
-outage), making "on by default" safe.
+This pass:
+- Pins **`BOOMI_RT_GRACE_SHARED=true`** in `cloudbuild.yaml` and
+  `k8s/deployment.yaml`. The code default is already `true`; pinning
+  makes the manifest reflect the intended state and prevents a
+  future default flip from silently turning Fix D off.
+- Pins **`BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true`** alongside it.
+  This is a real activation — the code default is `false`, so
+  before this PR concurrent refreshes across replicas could each
+  call Google independently. Pinning engages the Mongo
+  upsert-as-lock singleflight so only one replica calls Google per
+  refresh-token rotation.
+- Adds a scoped `boomi.*` stderr handler at INFO in `server.py`
+  (with its handler level pinned to INFO so propagated DEBUG records
+  from `boomi.oauth_diagnostic` don't leak past the parent filter)
+  so the patches' boot lines reach Cloud Logging without flooding
+  it with third-party chatter.
+
+Shared-cache read failures degrade to the local exchange path
+(no hard 401 on Mongo outage), so leaving these features on is safe
+even with intermittent Mongo connectivity.
 
 ### One-shot enable on a running revision
 
-If you want Fix D on **before** the next Cloud Build deploy completes:
+If you want Fix D.2 (distributed lock) on **before** the next Cloud
+Build deploy completes, or you want to flip an unset
+`BOOMI_RT_GRACE_SHARED` explicitly:
 
 ```bash
 gcloud run services update boomi-mcp-server \
   --region us-central1 --project boomimcp \
-  --update-env-vars BOOMI_RT_GRACE_SHARED=true
+  --update-env-vars BOOMI_RT_GRACE_SHARED=true,BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true
 ```
 
 `--update-env-vars` is additive — other env vars (`MONGODB_URI`,
@@ -430,8 +447,8 @@ replica during boot (filter substring → expected line):
 |---|---|---|
 | `Token verifier cache ENABLED` | `token_cache_patch` | Always (Fix B is on by default) |
 | `Refresh-token grace window ENABLED` | `refresh_token_grace_patch` | Always (Fix A is on by default) |
-| `Shared grace cache backend ENABLED` | `rt_grace_shared_backend` | Only after Fix 1 pinning |
-| `Distributed grace lock ENABLED` | `rt_grace_shared_backend` | Only after Fix 1 pinning |
+| `Shared grace cache backend ENABLED` | `rt_grace_shared_backend` | Whenever `BOOMI_RT_GRACE_SHARED!=false` (now pinned true) |
+| `Distributed grace lock ENABLED` | `rt_grace_shared_backend` | Only when `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true` (now pinned true) |
 
 Tail a single boot:
 
@@ -447,9 +464,26 @@ gcloud logging read 'resource.type="cloud_run_revision"
 
 ### Rollback
 
-Per-fix off-switches: set `BOOMI_RT_GRACE_SHARED=false` (or
-`--remove-env-vars BOOMI_RT_GRACE_SHARED`) to drop back to
-per-process-only grace. The local grace + singleflight from PR #33
-still protects each replica individually. The logging change is
+Per-fix off-switches require setting the value **explicitly to
+`false`** — `--remove-env-vars` alone is not enough for
+`BOOMI_RT_GRACE_SHARED` because its code default is `true` (and so
+unsetting it leaves the feature on). `BOOMI_RT_GRACE_DISTRIBUTED_LOCK`
+defaults to `false`, so for that one either `--update-env-vars
+=false` or `--remove-env-vars` works.
+
+```bash
+# Disable Fix D entirely (drops the shared cache back to local-only).
+gcloud run services update boomi-mcp-server \
+  --region us-central1 --project boomimcp \
+  --update-env-vars BOOMI_RT_GRACE_SHARED=false
+
+# Disable Fix D.2 only (keep shared cache, drop the distributed lock).
+gcloud run services update boomi-mcp-server \
+  --region us-central1 --project boomimcp \
+  --update-env-vars BOOMI_RT_GRACE_DISTRIBUTED_LOCK=false
+```
+
+The local grace + singleflight from PR #33 still protects each
+replica individually after either rollback. The logging change is
 pure observability — revert by removing the `_boomi_log` block at
 the top of `server.py`.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -127,12 +127,23 @@ spec:
           value: "true"
 
         # Cross-instance shared refresh-token grace cache (Fix D from
-        # PR #34). Defaults to off in the patch; we pin it on here so
-        # multi-replica refresh rotations share the grace window via
-        # Mongo and survive race conditions across pods. Shared reads
-        # degrade to local exchange on Mongo outage (no hard 401), so
-        # turning this on is safe even with intermittent Mongo issues.
+        # PR #34). The code default in
+        # rt_grace_shared_backend.initialize_shared_grace_backend is
+        # already "true"; we pin it here so the manifest reflects the
+        # intended state and a future default flip can't silently turn
+        # it off. Shared reads degrade to local exchange on Mongo outage
+        # (no hard 401), so leaving this on is safe.
         - name: BOOMI_RT_GRACE_SHARED
+          value: "true"
+
+        # Distributed grace lock (Fix D.2 from PR #34). Defaults to off
+        # in initialize_shared_grace_backend, so the shared cache alone
+        # still races on concurrent refreshes across replicas. Pinning
+        # this on engages the Mongo upsert-as-lock singleflight so only
+        # one replica calls Google per refresh-token rotation, even
+        # under simultaneous client retries. Adds one Mongo collection
+        # (`mcp-rt-inflight-locks`) and one upsert per refresh.
+        - name: BOOMI_RT_GRACE_DISTRIBUTED_LOCK
           value: "true"
 
         # Boomi Docs Knowledge Base (optional retrieval layer)

--- a/server.py
+++ b/server.py
@@ -31,9 +31,15 @@ from pathlib import Path
 # We deliberately leave propagate at its default (True) so pytest's caplog
 # (which attaches to root) still captures records — our own handler runs
 # first, and root has no configured handler so there's no double-emit.
+# The handler level is also pinned to INFO so DEBUG records propagated up
+# from a deliberately-verbose child (e.g. diagnostic_logging sets
+# boomi.oauth_diagnostic to DEBUG) do not leak past the parent filter:
+# logger.setLevel only filters records *originating* from that logger,
+# but propagated records bypass it and are filtered only by handler level.
 _boomi_log = logging.getLogger("boomi")
 if not _boomi_log.handlers:
     _h = logging.StreamHandler()
+    _h.setLevel(logging.INFO)
     _h.setFormatter(logging.Formatter("[%(levelname)s] [%(name)s] %(message)s"))
     _boomi_log.addHandler(_h)
     _boomi_log.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary

Three Codex findings on the merged PR #36, plus one self-discovered correction. Verified each finding against the code before fixing.

- **[P2] DEBUG records leak past handler's INFO filter.** `server.py`'s boomi handler was at NOTSET, so when `diagnostic_logging.apply_all_patches()` sets `boomi.oauth_diagnostic` to DEBUG, propagated DEBUG records bypass the parent logger's INFO setLevel (logger.setLevel only filters records originating from that logger; propagated records are filtered only by handler level). Reproed pre-fix; verified suppressed post-fix. Pinned handler level to INFO.

- **[P3] Runbook expected a log line that won't appear.** PR #36's runbook told operators to expect `Distributed grace lock ENABLED`, but `BOOMI_RT_GRACE_DISTRIBUTED_LOCK` defaults to `false`, so they'd actually see `DISABLED` and think rollout failed. Chose to ALSO pin `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true` (matching PR #34's stated intent of cross-instance singleflight) so the runbook's expectation holds and Fix D.2 is actually engaged in prod.

- **[P2] Rollback advice was broken.** `BOOMI_RT_GRACE_SHARED` defaults to `true` in code (since `bea0acc`), so `--remove-env-vars BOOMI_RT_GRACE_SHARED` only unsets it and the default takes effect — feature stays on. Rollback now uses `--update-env-vars BOOMI_RT_GRACE_SHARED=false` explicitly.

- **Self-discovered**: My original /goal verification claimed Fix D was dormant in prod. It wasn't — the code default has been `true` since PR #34. The pinning in PR #36 was redundant (still useful as defense against future default flips); the actual gap was Fix D.2, which this PR closes. Runbook "Why" paragraph corrected to reflect this.

## Test plan

- [x] DEBUG-leak repro before/after: pre-fix DEBUG line emits; post-fix it does not
- [x] Full pytest: 362 passed (unchanged from PR #36 baseline)
- [x] boomi-qa-tester agent: 5 tool calls clean, all 4 patches import, no regressions
- [ ] After merge: tail Cloud Logging for `Distributed grace lock ENABLED` line on the new revision

## Rollback

Per-fix off-switches now documented correctly in the runbook. Handler-level pin is pure observability — revert by removing `_h.setLevel(logging.INFO)`. Distributed lock pin can be flipped with `--update-env-vars BOOMI_RT_GRACE_DISTRIBUTED_LOCK=false`.