### PR TITLE
owner-scope release_lock so a stale leader cannot evict a fresh peer

### DIFF
--- a/refresh_token_grace_patch.py
+++ b/refresh_token_grace_patch.py
@@ -417,7 +417,7 @@ def apply_refresh_token_grace_patch(*, shared_backend=None) -> None:
         finally:
             if distributed_lock_held:
                 try:
-                    await shared_backend.release_lock(old_hash)
+                    await shared_backend.release_lock(old_hash, instance_id)
                 except Exception:  # noqa: BLE001
                     pass
 

--- a/rt_grace_shared_backend.py
+++ b/rt_grace_shared_backend.py
@@ -156,12 +156,25 @@ class SharedGraceBackend:
             )
             return True
 
-    async def release_lock(self, key: str) -> None:
-        """Best-effort lock release. Safe to call even if we never held it."""
+    async def release_lock(self, key: str, instance: str) -> None:
+        """Best-effort lock release. Safe to call even if we never held it.
+
+        Owner-scoped: the delete filter requires both the key AND the
+        instance label stamped into the lock at claim time. Without
+        that scoping, a stale leader that ran past `ttl_seconds`
+        (Mongo TTL-expired the lock, a peer claimed a fresh one) would
+        delete the new leader's lock in its `finally` block, re-opening
+        the duplicate-refresh race the lock is meant to prevent. The
+        same hazard exists when `try_claim_lock` returns True after an
+        ambiguous insert failure (the degrade-to-no-lock fallthrough):
+        the non-owner caller would otherwise unlock a real owner.
+        """
         if self._lock_collection is None:
             return
         try:
-            await self._lock_collection.delete_one({"_id": key})
+            await self._lock_collection.delete_one(
+                {"_id": key, "instance": instance}
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "release_lock failed for key=%s: %s: %s",

--- a/tests/test_refresh_token_grace_patch.py
+++ b/tests/test_refresh_token_grace_patch.py
@@ -372,9 +372,11 @@ class _FakeSharedBackend:
         self.lock_holder[key] = instance
         return True
 
-    async def release_lock(self, key):
+    async def release_lock(self, key, instance):
         self.release_calls += 1
-        self.lock_holder.pop(key, None)
+        # Owner-scoped: only the original claimant can release.
+        if self.lock_holder.get(key) == instance:
+            self.lock_holder.pop(key, None)
 
     async def write_failure_marker(self, key, error_type, short_ttl=5):
         self.failure_marker_calls += 1

--- a/tests/test_rt_grace_shared_backend.py
+++ b/tests/test_rt_grace_shared_backend.py
@@ -184,7 +184,15 @@ class _FakeLockCollection:
 
     async def delete_one(self, filt):
         self.delete_calls += 1
-        self.docs.pop(filt["_id"], None)
+        key = filt["_id"]
+        existing = self.docs.get(key)
+        if existing is None:
+            return None
+        # Match motor/pymongo semantics: only delete when every filter
+        # field matches the stored document. Owner-scoped release_lock
+        # passes both _id and instance, so the wrong instance is a no-op.
+        if all(existing.get(k) == v for k, v in filt.items() if k != "_id"):
+            del self.docs[key]
         return None
 
 
@@ -209,8 +217,45 @@ def test_release_lock_lets_next_claim_succeed():
     lock_coll = _FakeLockCollection()
     backend = SharedGraceBackend(_StubStore(), lock_collection=lock_coll)
     assert _run(backend.try_claim_lock("k1", 30, "A")) is True
-    _run(backend.release_lock("k1"))
+    _run(backend.release_lock("k1", "A"))
     assert _run(backend.try_claim_lock("k1", 30, "B")) is True
+
+
+def test_release_lock_wrong_instance_does_not_delete():
+    """A non-owner caller must not be able to delete another owner's lock.
+
+    This is the hazard when try_claim_lock returns True after an
+    ambiguous insert failure (the degrade-to-no-lock fallthrough):
+    the non-owner caller would otherwise unlock the real owner.
+    """
+    lock_coll = _FakeLockCollection()
+    backend = SharedGraceBackend(_StubStore(), lock_collection=lock_coll)
+    assert _run(backend.try_claim_lock("k1", 30, "A")) is True
+    _run(backend.release_lock("k1", "B"))  # wrong owner attempts release
+    # A's lock must survive — a fresh claim still loses.
+    assert _run(backend.try_claim_lock("k1", 30, "C")) is False
+    assert lock_coll.docs["k1"]["instance"] == "A"
+
+
+def test_stale_leader_release_does_not_evict_fresh_leader():
+    """The TTL-expiry race: a slow leader runs past the lock TTL,
+    Mongo's TTL sweep removes the lock, and a peer claims a fresh one.
+    The original leader's finally block must NOT delete the new
+    leader's lock — that would reopen the duplicate-refresh race the
+    lock exists to prevent.
+    """
+    lock_coll = _FakeLockCollection()
+    backend = SharedGraceBackend(_StubStore(), lock_collection=lock_coll)
+    # Stale leader claims, lock TTL-expires, peer claims fresh:
+    assert _run(backend.try_claim_lock("k1", 30, "stale-A")) is True
+    lock_coll.docs.pop("k1")  # simulate Mongo TTL eviction
+    assert _run(backend.try_claim_lock("k1", 30, "fresh-B")) is True
+    # Stale leader now returns from its slow exchange and releases:
+    _run(backend.release_lock("k1", "stale-A"))
+    # Fresh leader's lock must still be intact; a third peer still loses.
+    assert "k1" in lock_coll.docs
+    assert lock_coll.docs["k1"]["instance"] == "fresh-B"
+    assert _run(backend.try_claim_lock("k1", 30, "C")) is False
 
 
 def test_try_claim_lock_raises_when_locks_unsupported():


### PR DESCRIPTION
## Summary

Fixes a distributed-lock ownership bug surfaced after PR #37 enabled `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true` in prod.

**The hazard:** `SharedGraceBackend.release_lock(key)` deleted the lock document by `_id` only, ignoring ownership. Two scenarios where this re-opens the duplicate-refresh race the lock exists to prevent:

1. **TTL race.** A slow leader runs past `ttl_seconds`. Mongo's TTL sweep removes the lock. Another replica claims a fresh lock under the same `_id`. When the original leader's `finally` block runs `release_lock(key)`, it deletes the **new** leader's lock — a third replica can then claim. Multiple replicas end up calling Google for the same refresh-token rotation.
2. **Ambiguous-insert fallthrough.** `try_claim_lock` returns `True` on transient Mongo errors (degrade-to-no-lock semantics, line 150-157). The non-owner caller proceeds to `release_lock` in `finally` and deletes a real owner's lock.

**Fix:** `release_lock(key, instance)`. Delete filter is `{"_id": key, "instance": instance}` so only the original claimant can release. The caller at `refresh_token_grace_patch.py:420` already had `instance_id` in scope (built at module import from `HOSTNAME`/`gethostname`).

## Test plan

- [x] Full pytest: 364 passed (was 362; +2 new regression tests)
  - `test_release_lock_wrong_instance_does_not_delete` covers the ambiguous-insert hazard
  - `test_stale_leader_release_does_not_evict_fresh_leader` covers the TTL race
- [x] `_FakeLockCollection.delete_one` in tests updated to mimic real motor filter semantics (delete only when ALL filter fields match), so the regression tests actually exercise the new filter
- [x] `boomi-qa-tester` agent: 5 tool calls clean, all patches load, no regressions
- [ ] After merge: watch Cloud Logging for `release_lock failed` warnings on the new revision; expect zero in steady state

## Rollback

Single commit; `git revert <merge_commit>` restores the prior behavior (which has the hazard but is the same behavior shipped in PR #37).

## Notes for review

- The fix does NOT change `try_claim_lock`'s degrade-to-True fallthrough — that's intentional (deadlock-avoidance). Owner-scoped release is what makes the fallthrough safe.
- TTL-expired-leader case still produces a `release_lock failed` warning in logs (one delete returns `deleted_count=0`); that's expected diagnostic noise, not an error to alert on.