### PR TITLE
add motor dep so distributed grace lock engages in prod

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ python-dotenv>=1.0.0
 requests>=2.31.0
 itsdangerous>=2.1.0
 py-key-value-aio[mongodb]>=0.4.4,<0.5.0
+motor>=3.3,<4.0
 boomi>=2.1.1


### PR DESCRIPTION
## Summary
- Add `motor>=3.3,<4.0` to `requirements.txt`.

## Why
PR #38 (`oauth-release-lock-ownership`) shipped an owner-scoped `release_lock` for the distributed grace-cache singleflight, but Cloud Run logs from the latest revision (`boomi-mcp-server-00209-fxg`, image at `f30a482`) show the fix never actually engages:

```
[WARNING] [boomi.rt_grace_shared] Distributed grace lock init failed
(ModuleNotFoundError: No module named 'motor'); falling back to L2-cache-only
[INFO]    [boomi.refresh_token_grace] ... shared_backend=on, distributed_lock=off
```

`rt_grace_shared_backend.py:252` does a deferred `from motor.motor_asyncio import AsyncIOMotorClient`. The `py-key-value-aio[mongodb]` extra only pulls in `pymongo`, not `motor`, so with `BOOMI_RT_GRACE_DISTRIBUTED_LOCK=true` pinned (commit `e39718b`) the import raises, the broad `except` swallows it, and the leader/follower coordination silently degrades to L2-cache-only. Mongo confirms no `mcp-rt-inflight-locks` collection has ever been created.

## Test plan
- [ ] CI/build succeeds with the new dep.
- [ ] After deploy, startup logs show `Distributed grace lock ENABLED (collection=mcp-rt-inflight-locks)` and `distributed_lock=on` in the refresh-token-grace info line.
- [ ] Mongo shows the `mcp-rt-inflight-locks` collection with a TTL index on `expires_at`.