### PR TITLE
Defer Boomi Docs KB build off the import path (cold-start hang fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,22 +70,53 @@ RUN if [ -n "$KB_RELEASE_TAG" ]; then \
         tar -xzf /tmp/kb.tgz -C /app/kb && \
         rm /tmp/kb.tgz; \
     fi
+# Embedding-model cache location. Set BEFORE the preload so the model is baked
+# under an explicit, appuser-owned path (no mkdir/chown needed — /home/appuser is
+# already owned by appuser) that both the build-time validation below and the
+# runtime warmup resolve under HF_HUB_OFFLINE. NOT the offline flags yet: the
+# preload must reach Hugging Face to download the model.
+ENV HF_HOME=/home/appuser/.cache/huggingface \
+    SENTENCE_TRANSFORMERS_HOME=/home/appuser/.cache/sentence_transformers
+
 RUN if [ -n "$KB_RELEASE_TAG" ]; then \
         python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"; \
     fi
 
+# Build-time KB validation gate (Workstream C): run the full build_kb_service()
+# against the baked corpus with the offline flags set INLINE on this RUN. This
+# proves the corpus opens AND the embedding model resolves from the baked cache
+# with NO network — so a corrupt corpus / chunk-count mismatch / model-cache miss
+# fails the BUILD here instead of degrading to a runtime kb_unavailable. Backfills
+# the fast-fail guarantee the deferred warmup removed from the import path. Gated
+# by KB_RELEASE_TAG so a non-KB build skips it.
+RUN if [ -n "$KB_RELEASE_TAG" ]; then \
+        HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+        BOOMI_DOCS_ENABLED=true \
+        BOOMI_DOCS_DB_PATH=/app/kb/boomi_knowledge_db \
+        PYTHONPATH=/app/src \
+        python -c "from boomi_mcp.kb.service import build_kb_service; build_kb_service()"; \
+    fi
+
 # Environment variables (can be overridden at runtime)
+# HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE: the model is baked above (build-time
+# validation confirmed a cache hit), so the runtime warmup must NEVER reach the
+# network — an offline lookup is a guaranteed cache hit, while a network fetch on
+# a no-egress cold instance would make warming_up permanent.
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     MCP_HOST=0.0.0.0 \
     PORT=8080 \
     MCP_PATH=/mcp \
-    LOG_LEVEL=info
+    LOG_LEVEL=info \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
 
-# Health check - MCP server responds on /mcp path
-# Cloud Run sets PORT dynamically, default to 8080 for health check
+# Health check - mode-agnostic TCP/port check (NOT GET /mcp, which would 405
+# under the future stateless transport rollout and needs no new endpoint).
+# Cloud Run uses its own TCP startup probe regardless; this covers other
+# runtimes that honor HEALTHCHECK.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8080}/mcp || exit 1
+    CMD python -c "import socket,os,sys; s=socket.socket(); s.settimeout(5); sys.exit(0 if s.connect_ex(('127.0.0.1', int(os.getenv('PORT','8080'))))==0 else 1)"
 
 # Expose port (Cloud Run will override with PORT env var)
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ and embedded into the image at build time via
 [`deploy/kb-release.env`](deploy/kb-release.env). See
 [KB Release Promotion](#kb-release-promotion) below.
 
+**Cold-start behavior (operators).** The heavy KB build (Chroma + embedding
+model load) is deferred off the import path so the server binds its HTTP port
+immediately — the docs tools are registered *before* the KB is ready. On a
+scale-to-zero cold start the first call(s) may return a bounded
+`error: warming_up` (still loading — clients should wait `retry_after_seconds`
+and retry) or `error: kb_unavailable` (temporary build failure — self-heals on a
+later call after a cooldown). A docs call no longer hangs while the corpus loads.
+Tuning env vars: `BOOMI_DOCS_WARMUP_WAIT_SECONDS` (default 5 — max seconds a call
+blocks waiting for warmup), `BOOMI_DOCS_WARMUP_EAGER` (default true — kick the
+build on the first authenticated `/mcp` request), `BOOMI_DOCS_WARMUP_RETRY_COOLDOWN`
+(default 30 — seconds before a failed build re-attempts).
+
 ---
 
 ## Deployment

--- a/server.py
+++ b/server.py
@@ -65,7 +65,13 @@ KB_INSTRUCTIONS = (
     "consult `search_boomi_docs` before answering from model memory. Prefer "
     "retrieved KB evidence over parametric knowledge because Boomi documentation "
     "changes. If search returns `low_confidence` or `no_match`, say the KB does "
-    "not provide enough support rather than inventing details."
+    "not provide enough support rather than inventing details. If a docs tool "
+    "returns `error: warming_up`, the knowledge base is still loading after a "
+    "cold start — wait `retry_after_seconds` and retry the same call rather than "
+    "treating it as a failure or answering from memory. If it returns "
+    "`error: kb_unavailable`, documentation retrieval is temporarily unavailable; "
+    "tell the user docs are momentarily unavailable (a later retry may succeed) "
+    "rather than inventing Boomi facts."
 )
 
 
@@ -3823,17 +3829,52 @@ if not LOCAL_MODE:
 
 
 # --- Boomi Docs KB (optional) ---
-# Registered only when BOOMI_DOCS_ENABLED=true. The import below is what pulls in
-# chromadb/sentence-transformers, so a default server never loads the ML stack.
+# Registered only when BOOMI_DOCS_ENABLED=true. The CHEAP validation runs at
+# import (fail-fast for misconfigured corpora); the HEAVY build (chromadb +
+# embedding model) is deferred to KbWarmup so it never blocks the import path or
+# uvicorn's socket bind. The tools/resource register immediately and the first
+# docs call after a cold start returns a bounded warming_up / kb_unavailable
+# instead of hanging.
 if BOOMI_DOCS_ENABLED:
-    from boomi_mcp.kb.service import build_kb_service
+    from boomi_mcp.kb.service import validate_kb_manifest_cheap
+    from boomi_mcp.kb.warmup import KbWarmup
     from boomi_mcp.kb.manifest import render_corpus_resource
 
+    def _kb_env_float(name, default):
+        raw = os.getenv(name)
+        if raw is None or raw.strip() == "":
+            return default
+        try:
+            return float(raw)
+        except ValueError:
+            print(f"[WARNING] {name}={raw!r} is not a number; using default {default}")
+            return default
+
+    def _kb_env_flag(name, default):
+        return os.getenv(name, default).strip().lower() in ("true", "1", "yes", "on")
+
+    # Cheap, ML-free validation still runs at import so a misconfigured corpus
+    # fails fast (preserves the existing fail-fast contract for the cheap-
+    # detectable problems: missing path, bad/missing manifest, schema/collection
+    # mismatch, missing embedding_model). The heavy chunk-count/probe checks now
+    # run in the deferred build and are backfilled at Docker build time.
     try:
-        _kb_service = build_kb_service()
+        _kb_bootstrap = validate_kb_manifest_cheap()
     except Exception as e:
         print(f"[ERROR] Boomi Docs KB startup failed: {e}")
         sys.exit(1)
+
+    # Max seconds a docs call blocks for warmup before returning warming_up.
+    _WARMUP_WAIT = _kb_env_float("BOOMI_DOCS_WARMUP_WAIT_SECONDS", 5.0)
+    _WARMUP_RETRY_COOLDOWN = _kb_env_float("BOOMI_DOCS_WARMUP_RETRY_COOLDOWN", 30.0)
+    # Read by server_http.py to decide whether to install the eager first-request
+    # warmup hook. Opportunistic only — get() at the first tool call is the
+    # correctness path.
+    _kb_warmup_eager = _kb_env_flag("BOOMI_DOCS_WARMUP_EAGER", "true")
+
+    _kb_warmup = KbWarmup(
+        _kb_bootstrap, retry_cooldown_seconds=_WARMUP_RETRY_COOLDOWN
+    )
 
     @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": False})
     def search_boomi_docs(query: str, top_k: int = None) -> dict:
@@ -3849,12 +3890,27 @@ if BOOMI_DOCS_ENABLED:
         page_key. If results look off-topic, retry with reformulated query terms.
         If the response status is low_confidence or no_match, do not invent
         unsupported Boomi facts; tell the user the KB does not provide enough
-        support. Read-only.
+        support. If the response is error "warming_up", the KB is still loading
+        after a cold start — wait retry_after_seconds and retry the same call. If
+        it is error "kb_unavailable", docs retrieval is temporarily unavailable;
+        report that rather than inventing facts (a later retry may succeed).
+        Read-only.
         """
+        svc = _kb_warmup.get(_WARMUP_WAIT)
+        if svc is None:
+            return _kb_warmup.not_ready_response()
         try:
-            return _kb_service.search(query, top_k)
+            return svc.search(query, top_k)
         except Exception as e:
-            return {"_success": False, "error": "kb_query_error", "message": str(e)}
+            # Sanitize: full detail server-side only; client gets a generic
+            # message + coarse category (KbQueryError text can embed internals).
+            print(f"[ERROR] search_boomi_docs query failed: {e}")
+            return {
+                "_success": False,
+                "error": "kb_query_error",
+                "message": "Boomi Docs KB query failed. Please retry shortly.",
+                "error_type": type(e).__name__,
+            }
 
     @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": False})
     def read_boomi_doc_page(
@@ -3868,12 +3924,24 @@ if BOOMI_DOCS_ENABLED:
         step sequences, or sections adjacent to the matched chunk. Most Boomi doc
         pages fit in a single call (default 15 chunks); if the response has
         "truncated": true, call again with start_chunk_index set to the returned
-        next_chunk_index to continue. Read-only.
+        next_chunk_index to continue. If the response is error "warming_up", the
+        KB is still loading after a cold start — wait retry_after_seconds and
+        retry. If it is error "kb_unavailable", docs retrieval is temporarily
+        unavailable. Read-only.
         """
+        svc = _kb_warmup.get(_WARMUP_WAIT)
+        if svc is None:
+            return _kb_warmup.not_ready_response()
         try:
-            return _kb_service.read_page(page_key, max_chunks, start_chunk_index)
+            return svc.read_page(page_key, max_chunks, start_chunk_index)
         except Exception as e:
-            return {"_success": False, "error": "kb_query_error", "message": str(e)}
+            print(f"[ERROR] read_boomi_doc_page failed: {e}")
+            return {
+                "_success": False,
+                "error": "kb_query_error",
+                "message": "Boomi Docs KB query failed. Please retry shortly.",
+                "error_type": type(e).__name__,
+            }
 
     @mcp.resource("kb://boomi-docs/corpus", mime_type="text/markdown")
     def boomi_docs_corpus() -> str:
@@ -3882,10 +3950,14 @@ if BOOMI_DOCS_ENABLED:
         breakdown, and known exclusions. Static — not the retrieval path; use
         search_boomi_docs and read_boomi_doc_page for lookups.
         """
-        return render_corpus_resource(_kb_service.manifest)
+        # Rendered from the cheap bootstrap manifest, not a live KbService, so
+        # the coverage map is available immediately and regardless of warmup
+        # state (warming or failed).
+        return render_corpus_resource(_kb_bootstrap.manifest)
 
     print("[INFO] Boomi Docs KB registered: tools search_boomi_docs, "
-          "read_boomi_doc_page; resource kb://boomi-docs/corpus")
+          "read_boomi_doc_page; resource kb://boomi-docs/corpus "
+          "(heavy build deferred to first use / eager warmup)")
 
 
 if __name__ == "__main__":

--- a/server_http.py
+++ b/server_http.py
@@ -13,6 +13,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.staticfiles import StaticFiles
 
 from mcp_stream_guard import (
+    DEFAULT_MCP_PATH,
     McpStreamGuardConfig,
     McpStreamGuardMiddleware,
     McpStreamGuardState,
@@ -21,8 +22,72 @@ from mcp_stream_guard import (
     install_reaper_lifespan,
 )
 
+
+class FirstRequestWarmupMiddleware:
+    """One-shot ASGI hook: kick the deferred KB warmup on the first AUTHENTICATED
+    /mcp request.
+
+    Composed INTO ``mcp.http_app(middleware=[...])`` (NOT app.add_middleware /
+    an outer wrapper), so it runs as APP-LEVEL middleware: after the auth
+    provider has parsed the bearer principal onto the scope, but BEFORE the
+    route-level RequireAuthMiddleware that enforces the 401. It is therefore NOT
+    behind the 401 — an unauthenticated /mcp request still reaches it — so it
+    must self-check the authenticated principal and kick ONLY when authenticated.
+    That keeps the expensive ML warmup from running for unauthenticated callers.
+
+    Gating:
+      * scope['type'] == 'http' — pass through 'lifespan' (sent pre-bind;
+        kicking there would recreate the import-time contention this avoids) and
+        any other scope.
+      * path is the /mcp endpoint — never web UI / OAuth / static traffic.
+      * the parsed principal is authenticated (mirrors the route-level 401's
+        ``isinstance(scope['user'], AuthenticatedUser)`` via the Starlette
+        ``user.is_authenticated`` contract).
+
+    Eager warmup is opportunistic only; correctness rests on KbWarmup.get() at
+    the first tool call. The single-build guarantee is KbWarmup.kick()'s
+    lock-guarded idempotency, so a benign race between two first requests (or the
+    unsynchronized _fired flag) cannot start two builds.
+    """
+
+    def __init__(self, app, warmup, mcp_path=DEFAULT_MCP_PATH):
+        self.app = app
+        self._warmup = warmup
+        self._mcp_path = (mcp_path or DEFAULT_MCP_PATH).rstrip("/") or DEFAULT_MCP_PATH
+        self._fired = False
+
+    def _is_mcp_path(self, scope):
+        return (scope.get("path") or "").rstrip("/") == self._mcp_path
+
+    @staticmethod
+    def _is_authenticated(scope):
+        # Starlette's AuthenticationMiddleware (added by the FastMCP auth
+        # provider) sets scope['user']; AuthenticatedUser.is_authenticated is
+        # True, UnauthenticatedUser.is_authenticated is False. Absent user
+        # (no auth configured) -> treat as unauthenticated and do not kick.
+        return bool(getattr(scope.get("user"), "is_authenticated", False))
+
+    async def __call__(self, scope, receive, send):
+        if (
+            not self._fired
+            and scope.get("type") == "http"
+            and self._is_mcp_path(scope)
+            and self._is_authenticated(scope)
+        ):
+            self._fired = True
+            try:
+                self._warmup.kick()
+            except Exception as e:  # noqa: BLE001 — never break request handling
+                print(f"[WARNING] eager KB warmup kick failed: {e}")
+        await self.app(scope, receive, send)
+
+
 if __name__ == "__main__":
-    # Import mcp from server module (ensures OAuth provider is initialized)
+    # Import mcp from server module (ensures OAuth provider is initialized).
+    # `import server` (not just the from-import) lets us reach the optional
+    # _kb_warmup / _kb_warmup_eager attributes, which exist only when
+    # BOOMI_DOCS_ENABLED is set.
+    import server
     from server import mcp
 
     # Get configuration from environment
@@ -52,10 +117,25 @@ if __name__ == "__main__":
     print(f"{'='*60}\n")
 
     # Create the HTTP app with all routes (MCP + OAuth).
-    # The MCP stream cost guard is bound through http_app(middleware=[...]) so it
-    # runs INSIDE the FastMCP auth middleware (bearer token already on the scope)
-    # but still wraps /mcp request handling. Do NOT use app.add_middleware() for
-    # it — that prepends as outermost, before auth.
+    # The MCP stream cost guard and the eager KB warmup hook are bound through
+    # http_app(middleware=[...]) so they run INSIDE the FastMCP auth middleware
+    # (bearer token already parsed onto the scope) but still wrap /mcp request
+    # handling. Do NOT use app.add_middleware() for them — that prepends as
+    # outermost, before auth, so the warmup hook could not see the principal and
+    # could fire for unauthenticated callers.
+    #
+    # Eager warmup hook: installed only when the KB is enabled (warmup present)
+    # AND BOOMI_DOCS_WARMUP_EAGER is on. It is opportunistic — get() at the first
+    # tool call remains the correctness path. Placed first (outermost custom
+    # middleware) so it observes every authenticated /mcp request before the
+    # guard, then forwards untouched.
+    _kb_warmup = getattr(server, "_kb_warmup", None)
+    _kb_warmup_eager = getattr(server, "_kb_warmup_eager", False)
+    warmup_mw = []
+    if _kb_warmup is not None and _kb_warmup_eager:
+        warmup_mw = [Middleware(FirstRequestWarmupMiddleware, warmup=_kb_warmup)]
+        print("[INFO] Eager KB warmup hook enabled (first authenticated /mcp request)")
+
     guard_config = McpStreamGuardConfig.from_env()
     guard_state = McpStreamGuardState(guard_config)
     if guard_config.enabled:
@@ -67,14 +147,15 @@ if __name__ == "__main__":
             f"session_idle={guard_config.session_idle_seconds}s)"
         )
         app = mcp.http_app(
-            middleware=[Middleware(McpStreamGuardMiddleware, state=guard_state)]
+            middleware=warmup_mw
+            + [Middleware(McpStreamGuardMiddleware, state=guard_state)]
         )
         bind_fastmcp_session_manager(app, guard_state)
         bind_auth_jwt_issuer(app, guard_state)
         install_reaper_lifespan(app, guard_state)
     else:
         print("[INFO] MCP stream guard disabled (BOOMI_MCP_STREAM_GUARD_ENABLED=false)")
-        app = mcp.http_app()
+        app = mcp.http_app(middleware=warmup_mw)
 
     # Mount static files directory
     static_dir = os.path.join(os.path.dirname(__file__), "static")

--- a/src/boomi_mcp/categories/meta_tools.py
+++ b/src/boomi_mcp/categories/meta_tools.py
@@ -5795,7 +5795,11 @@ def list_capabilities_action(available_tools: set = None) -> Dict[str, Any]:
             "note": (
                 "Use this before answering factual Boomi platform behavior, "
                 "connector, configuration, deployment/runtime, scripting, EDI/API, "
-                "or error-message questions."
+                "or error-message questions. After a scale-to-zero cold start the "
+                "first call may return error 'warming_up' (the KB is still "
+                "loading — wait retry_after_seconds and retry the same call) or "
+                "'kb_unavailable' (temporarily unavailable — report that rather "
+                "than inventing facts; a later retry may succeed)."
             ),
         },
         "read_boomi_doc_page": {
@@ -6144,7 +6148,9 @@ def list_capabilities_action(available_tools: set = None) -> Dict[str, Any]:
         hints["boomi_docs"] = (
             "For factual Boomi product behavior, connector/configuration semantics, "
             "runtime behavior, EDI/API behavior, scripting, or error messages, "
-            "start with search_boomi_docs()."
+            "start with search_boomi_docs(). On a cold start it may return "
+            "'warming_up' (wait retry_after_seconds and retry) or 'kb_unavailable' "
+            "(temporarily unavailable — don't invent facts)."
         )
     # Only recommend the archetype-first flow when the entry-point tool is
     # actually registered; otherwise the hint points at a tool the catalog

--- a/src/boomi_mcp/kb/service.py
+++ b/src/boomi_mcp/kb/service.py
@@ -1,12 +1,23 @@
 """Boomi docs knowledge base retrieval service.
 
 chromadb and sentence-transformers are imported lazily inside
-``build_kb_service`` so that merely importing this module does not pull in the
-ML stack. server.py only imports this module when ``BOOMI_DOCS_ENABLED`` is
-true, and ``build_kb_service`` is the single entry point that touches the heavy
-dependencies.
+``build_kb_service_heavy`` so that merely importing this module does not pull in
+the ML stack. server.py only imports this module when ``BOOMI_DOCS_ENABLED`` is
+true. The startup sequence is split into two halves so the heavy half can be
+deferred off the import/socket-bind path (see boomi_mcp.kb.warmup):
+
+* ``validate_kb_manifest_cheap`` — pure-stdlib config + manifest validation
+  (no ML imports). Run at import so a misconfigured corpus still fails fast.
+* ``build_kb_service_heavy`` — opens Chroma + loads the embedding model. This is
+  the multi-second cold-start cost; it is the single entry point that touches
+  the heavy dependencies.
+
+``build_kb_service`` composes the two and keeps its original signature/behavior
+(used by the Docker build-time validation gate and the startup test matrix).
 """
 import os
+import time
+from dataclasses import dataclass
 
 from .errors import KbQueryError, KbStartupError
 from .manifest import corpus_version, load_manifest, validate_manifest
@@ -338,12 +349,28 @@ class KbService:
         return result
 
 
-def build_kb_service():
-    """Run the spec §4.3 startup sequence and return a ready KbService.
+@dataclass(frozen=True)
+class KbBootstrap:
+    """Cheap, ML-free startup state produced by ``validate_kb_manifest_cheap``.
 
-    Raises KbStartupError on any validation failure. chromadb and
-    sentence-transformers are imported here (and nowhere else at import time),
-    so a server with BOOMI_DOCS_ENABLED unset never loads the ML stack.
+    Carries both the resolved ``config`` and the parsed ``manifest`` because the
+    heavy build AND KbService need config (db_path/collection/top_k/confidence),
+    not just the manifest. Held by KbWarmup and handed to ``build_kb_service_heavy``
+    when the deferred build runs.
+    """
+
+    config: dict
+    manifest: dict
+
+
+def validate_kb_manifest_cheap():
+    """Run the cheap, pure-stdlib half of the spec §4.3 startup sequence.
+
+    Resolves config, checks the corpus path, loads + validates the manifest, and
+    confirms the embedding_model field is present. Imports NO ML dependencies, so
+    it is safe to run on the import/socket-bind path (server.py runs it at import
+    to preserve fail-fast for cheap-detectable corpus problems). Raises
+    KbStartupError on any failure. Returns a KbBootstrap for build_kb_service_heavy.
     """
     config = _kb_config()
     db_path = config["db_path"]
@@ -357,7 +384,37 @@ def build_kb_service():
     # Steps 3-4: manifest schema version + collection name.
     validate_manifest(manifest, collection_name)
 
+    # Embedding-model presence is a cheap manifest check; fail fast here (moved
+    # ahead of the heavy chromadb import) so a model-less manifest never defers a
+    # build that is guaranteed to fail.
+    if not manifest.get("embedding_model"):
+        raise KbStartupError("KB manifest is missing 'embedding_model'")
+
+    return KbBootstrap(config=config, manifest=manifest)
+
+
+def build_kb_service_heavy(bootstrap):
+    """Run the heavy half of startup and return a ready KbService.
+
+    Opens the Chroma client + collection and loads the SentenceTransformer
+    embedding model — the multi-second cold-start cost. chromadb and
+    sentence-transformers are imported here (and nowhere else at import time),
+    so a server with BOOMI_DOCS_ENABLED unset never loads the ML stack and the
+    deferred warmup thread is the only place this cost is paid in production.
+    Emits per-phase timing logs so the cold-start breakdown is measurable in
+    Cloud Logging. Raises KbStartupError on any failure.
+    """
+    config = bootstrap.config
+    manifest = bootstrap.manifest
+    db_path = config["db_path"]
+    collection_name = config["collection"]
+    embedding_model = manifest.get("embedding_model")
+
+    def _phase(name, start):
+        print(f"[INFO] KB warmup phase={name} seconds={time.monotonic() - start:.2f}")
+
     # Heavy dependencies are imported only after the cheap checks pass.
+    t = time.monotonic()
     try:
         import chromadb
         from chromadb.utils import embedding_functions
@@ -366,34 +423,39 @@ def build_kb_service():
             "KB dependencies are not installed — install requirements-kb.txt "
             f"(chromadb, sentence-transformers): {e}"
         )
+    _phase("import_deps", t)
 
     # Step 5: open the persistent client.
+    t = time.monotonic()
     try:
         client = chromadb.PersistentClient(path=db_path)
     except Exception as e:
         raise KbStartupError(f"Failed to open Chroma client at {db_path}: {e}")
+    _phase("open_client", t)
 
     # Step 8 (before 6): the embedding function is required to re-open the
     # collection so that query_texts work — so build it before get_collection.
-    embedding_model = manifest.get("embedding_model")
-    if not embedding_model:
-        raise KbStartupError("KB manifest is missing 'embedding_model'")
+    t = time.monotonic()
     try:
         ef = embedding_functions.SentenceTransformerEmbeddingFunction(
             model_name=embedding_model
         )
     except Exception as e:
         raise KbStartupError(f"Failed to load embedding model {embedding_model!r}: {e}")
+    _phase("load_model", t)
 
     # Step 6: open the collection.
+    t = time.monotonic()
     try:
         collection = client.get_collection(name=collection_name, embedding_function=ef)
     except Exception as e:
         raise KbStartupError(
             f"Failed to open Chroma collection {collection_name!r}: {e}"
         )
+    _phase("open_collection", t)
 
     # Step 7: exact count match guards against incomplete/corrupt artifacts.
+    t = time.monotonic()
     expected_count = manifest.get("chunk_count")
     actual_count = collection.count()
     if actual_count != expected_count:
@@ -401,14 +463,17 @@ def build_kb_service():
             f"KB corpus chunk count mismatch: collection has {actual_count}, "
             f"manifest declares {expected_count}"
         )
+    _phase("count", t)
 
     # Step 9: a probe query must return something.
+    t = time.monotonic()
     try:
         probe = collection.query(query_texts=["probe"], n_results=1)
     except Exception as e:
         raise KbStartupError(f"KB probe query failed: {e}")
     if not (probe.get("ids") and probe["ids"][0]):
         raise KbStartupError("KB probe query returned no results — corpus may be empty")
+    _phase("probe", t)
 
     service = KbService(collection, manifest, config)
     print(
@@ -417,3 +482,14 @@ def build_kb_service():
         f"built={manifest.get('build_timestamp', 'unknown')}"
     )
     return service
+
+
+def build_kb_service():
+    """Run the full spec §4.3 startup sequence and return a ready KbService.
+
+    Thin orchestrator: ``build_kb_service_heavy(validate_kb_manifest_cheap())``.
+    Unchanged public signature/behavior — used by the Docker build-time
+    validation gate and the startup test matrix. Raises KbStartupError on any
+    validation failure.
+    """
+    return build_kb_service_heavy(validate_kb_manifest_cheap())

--- a/src/boomi_mcp/kb/warmup.py
+++ b/src/boomi_mcp/kb/warmup.py
@@ -22,6 +22,7 @@ Design notes:
   the full exception detail is logged server-side only.
 """
 import logging
+import math
 import threading
 import time
 
@@ -33,10 +34,12 @@ WARMING = "warming"
 READY = "ready"
 FAILED = "failed"
 
-# Client-facing retry hints (seconds). warming_up matches the default in-request
-# wait; kb_unavailable matches the default failed-build retry cooldown.
+# Client-facing retry hint for warming_up (seconds) — matches the default
+# in-request wait; a short poll interval while the build is in flight. The
+# kb_unavailable hint is NOT a constant: it is derived from the REMAINING retry
+# cooldown (see not_ready_response), so a tuned BOOMI_DOCS_WARMUP_RETRY_COOLDOWN
+# never leaves clients retrying before a re-kick is even possible.
 WARMING_UP_RETRY_AFTER = 5
-KB_UNAVAILABLE_RETRY_AFTER = 30
 
 # Build-running-longer-than this logs a STUCK warning (detection only — Python
 # cannot force-kill the thread; the bounded get() wait already prevents any
@@ -146,6 +149,7 @@ class KbWarmup:
         with self._lock:
             state = self._state
             error_type = self._error_type
+            retry_after = self._remaining_cooldown_locked()
         if state == FAILED:
             logger.info("KB_RESPONSE status=kb_unavailable error_type=%s", error_type)
             return {
@@ -153,7 +157,10 @@ class KbWarmup:
                 "error": "kb_unavailable",
                 "message": "Boomi Docs KB is temporarily unavailable. Please retry shortly.",
                 "error_type": error_type or "KbStartupError",
-                "retry_after_seconds": KB_UNAVAILABLE_RETRY_AFTER,
+                # Soonest a retry could change state = when the cooldown lets the
+                # next get() re-kick. Tracks the configured cooldown, not a fixed
+                # default, so clients don't retry into kb_unavailable.
+                "retry_after_seconds": retry_after,
             }
         # IDLE or WARMING (incl. a retry build in flight) -> still loading.
         logger.info("KB_RESPONSE status=warming_up")
@@ -198,6 +205,22 @@ class KbWarmup:
                 type(error).__name__,
                 error,
             )
+
+    def _remaining_cooldown_locked(self):
+        """Seconds until a failed build may re-attempt, as an int >= 1.
+
+        Caller must hold the lock. Returns the remaining slice of the configured
+        retry cooldown since the last failure (or the full cooldown right after a
+        failure); clamped to >= 1 so the client always gets a positive retry hint
+        and an already-elapsed cooldown reads as "retry now".
+
+        Rounds UP (ceil): this is the soonest a retry can CHANGE state, so a hint
+        that rounded a fractional remainder down (e.g. 2.4 -> 2) would have the
+        client retry before kick()'s cooldown elapses and get another
+        kb_unavailable. Ceiling lands the retry at or just past the boundary.
+        """
+        remaining = self._retry_cooldown - (self._time() - (self._failed_at or 0.0))
+        return max(1, math.ceil(remaining))
 
     def _maybe_log_stuck_locked(self):
         """Log once if the in-flight build has exceeded the stuck threshold.

--- a/src/boomi_mcp/kb/warmup.py
+++ b/src/boomi_mcp/kb/warmup.py
@@ -1,0 +1,215 @@
+"""Deferred, thread-safe warmup of the Boomi docs KB.
+
+The heavy KB build (Chroma open + embedding-model load) is the dominant
+cold-start cost. Running it at module import blocks uvicorn's socket bind, so a
+cold Cloud Run instance accepts zero connections until it finishes and the
+client times out. ``KbWarmup`` moves that build off the import path into a
+single daemon thread and lets MCP tool calls return a bounded structured
+response (``warming_up``) instead of hanging.
+
+Design notes:
+
+* ``threading`` primitives (NOT asyncio) — FastMCP runs the sync ``def`` KB
+  tools in worker threads via ``anyio.to_thread``, so ``get()`` is called from a
+  thread, never the event loop.
+* Single in-flight build, guarded by a lock; ``kick()`` is idempotent so racing
+  callers (the eager first-request hook and the first tool call) never start two
+  builds.
+* State machine ``idle -> warming -> ready | failed`` with self-heal: a failed
+  build re-attempts after a cooldown on the next ``get()`` (a transient OOM/disk
+  failure recovers without an instance restart).
+* No detail leak: client responses carry a generic message + coarse error_type;
+  the full exception detail is logged server-side only.
+"""
+import logging
+import threading
+import time
+
+logger = logging.getLogger("boomi.kb.warmup")
+
+# State machine values.
+IDLE = "idle"
+WARMING = "warming"
+READY = "ready"
+FAILED = "failed"
+
+# Client-facing retry hints (seconds). warming_up matches the default in-request
+# wait; kb_unavailable matches the default failed-build retry cooldown.
+WARMING_UP_RETRY_AFTER = 5
+KB_UNAVAILABLE_RETRY_AFTER = 30
+
+# Build-running-longer-than this logs a STUCK warning (detection only — Python
+# cannot force-kill the thread; the bounded get() wait already prevents any
+# client hang, so a stuck build degrades to persistent warming_up, not a hang).
+DEFAULT_STUCK_AFTER_SECONDS = 120.0
+
+
+class KbWarmup:
+    """Owns the deferred heavy KB build and serves a state-based readiness view."""
+
+    def __init__(
+        self,
+        bootstrap,
+        builder=None,
+        retry_cooldown_seconds=30.0,
+        stuck_after_seconds=DEFAULT_STUCK_AFTER_SECONDS,
+        time_fn=time.monotonic,
+    ):
+        self._bootstrap = bootstrap
+        if builder is None:
+            # Imported lazily so this module stays ML-free at import; importing
+            # the function object does not import chromadb (that happens inside
+            # build_kb_service_heavy's body).
+            from .service import build_kb_service_heavy
+
+            builder = build_kb_service_heavy
+        self._builder = builder
+        self._retry_cooldown = float(retry_cooldown_seconds)
+        self._stuck_after = float(stuck_after_seconds)
+        self._time = time_fn
+
+        self._lock = threading.Lock()
+        self._done = threading.Event()
+        self._state = IDLE
+        self._service = None
+        self._error = None
+        self._error_type = None
+        self._failed_at = None
+        self._started_at = None
+        self._stuck_logged = False
+        self._thread = None
+
+    # -- public API --------------------------------------------------------- #
+    def kick(self):
+        """Idempotently ensure a single build is running.
+
+        No-op while a build is in flight (WARMING) or already done (READY).
+        From FAILED, restarts only after the retry cooldown has elapsed
+        (self-heal). Safe to call concurrently from many worker threads — the
+        lock guarantees at most one in-flight build.
+        """
+        with self._lock:
+            if self._state in (WARMING, READY):
+                return
+            is_retry = False
+            if self._state == FAILED:
+                elapsed = self._time() - (self._failed_at or 0.0)
+                if elapsed < self._retry_cooldown:
+                    return
+                is_retry = True
+
+            # idle, or failed + cooldown elapsed -> (re)start a fresh build.
+            self._state = WARMING
+            self._service = None
+            self._error = None
+            self._error_type = None
+            self._failed_at = None
+            self._started_at = self._time()
+            self._stuck_logged = False
+            self._done = threading.Event()
+            done = self._done
+            thread = threading.Thread(
+                target=self._run, args=(done,), name="kb-warmup", daemon=True
+            )
+            self._thread = thread
+            logger.info("KB_WARMUP_RETRY" if is_retry else "KB_WARMUP_STARTED")
+        thread.start()
+
+    def get(self, wait_seconds):
+        """Return the ready KbService, or None if not ready within wait_seconds.
+
+        Always kicks first so warmup proceeds even when the eager hook is off /
+        never fired (otherwise an instance could report warming_up forever). The
+        bounded wait holds a request in flight (CPU allocated on request-billed
+        Cloud Run) so the build advances. Returns None for warming AND failed —
+        the caller renders not_ready_response() for the exact client status.
+        """
+        self.kick()
+        with self._lock:
+            if self._state == READY:
+                return self._service
+            done = self._done
+        done.wait(timeout=max(0.0, float(wait_seconds)))
+        with self._lock:
+            if self._state == READY:
+                return self._service
+            self._maybe_log_stuck_locked()
+            return None
+
+    def not_ready_response(self):
+        """Structured client response for a not-ready state (read under lock).
+
+        Keyed off the CURRENT state, never error history: a cooldown re-kick
+        (state back to WARMING) reports warming_up, not stale kb_unavailable.
+        Carries no raw exception detail — only a coarse error_type category.
+        """
+        with self._lock:
+            state = self._state
+            error_type = self._error_type
+        if state == FAILED:
+            logger.info("KB_RESPONSE status=kb_unavailable error_type=%s", error_type)
+            return {
+                "_success": False,
+                "error": "kb_unavailable",
+                "message": "Boomi Docs KB is temporarily unavailable. Please retry shortly.",
+                "error_type": error_type or "KbStartupError",
+                "retry_after_seconds": KB_UNAVAILABLE_RETRY_AFTER,
+            }
+        # IDLE or WARMING (incl. a retry build in flight) -> still loading.
+        logger.info("KB_RESPONSE status=warming_up")
+        return {
+            "_success": False,
+            "error": "warming_up",
+            "message": "Boomi Docs KB is still loading. Retry shortly.",
+            "retry_after_seconds": WARMING_UP_RETRY_AFTER,
+        }
+
+    # -- internals ---------------------------------------------------------- #
+    def _run(self, done):
+        start = self._time()
+        service = None
+        error = None
+        try:
+            service = self._builder(self._bootstrap)
+        except Exception as e:  # noqa: BLE001 — record, never crash the thread
+            error = e
+        # Set the terminal state under the lock BEFORE signalling done, so a
+        # waiter woken by done.set() always reads the final state (no transient
+        # warming_up after a successful build).
+        with self._lock:
+            if self._done is done:  # ignore a superseded build's result
+                if error is None:
+                    self._state = READY
+                    self._service = service
+                    self._error = None
+                    self._error_type = None
+                else:
+                    self._state = FAILED
+                    self._service = None
+                    self._error = str(error)
+                    self._error_type = type(error).__name__
+                    self._failed_at = self._time()
+        done.set()
+        if error is None:
+            logger.info("KB_WARMUP_SUCCEEDED seconds=%.2f", self._time() - start)
+        else:
+            logger.error(
+                "KB_WARMUP_FAILED error_type=%s detail=%s",
+                type(error).__name__,
+                error,
+            )
+
+    def _maybe_log_stuck_locked(self):
+        """Log once if the in-flight build has exceeded the stuck threshold.
+
+        Caller must hold the lock. Detection only (see module docstring)."""
+        if (
+            self._state == WARMING
+            and not self._stuck_logged
+            and self._started_at is not None
+            and (self._time() - self._started_at) >= self._stuck_after
+        ):
+            self._stuck_logged = True
+            logger.warning(
+                "KB_WARMUP_STUCK seconds=%.2f", self._time() - self._started_at
+            )

--- a/tests/kb/test_resource.py
+++ b/tests/kb/test_resource.py
@@ -23,6 +23,7 @@ os.environ["BOOMI_DOCS_DB_PATH"] = get_fixture_corpus()
 os.environ["BOOMI_DOCS_COLLECTION"] = "boomi_docs"
 
 import server  # noqa: E402
+from boomi_mcp.kb import warmup as warmup_mod  # noqa: E402
 
 CORPUS_URI = "kb://boomi-docs/corpus"
 
@@ -55,3 +56,26 @@ def test_corpus_resource_reads_as_coverage_map():
     assert "EDI (5)" in body
     assert "Known exclusions:" in body
     assert "search_boomi_docs" in body
+
+
+def test_resource_is_independent_of_warmup_state():
+    """The resource renders from the cheap bootstrap manifest, not a live
+    KbService, so it must return the same coverage map in EVERY warmup state —
+    not-yet-built, warming, ready, and failed. State is saved/restored so this
+    does not pollute the warmup shared with other modules in the same process."""
+    expected = _read_resource_text(CORPUS_URI)
+    assert expected.startswith("# Boomi Documentation Corpus")
+
+    w = server._kb_warmup
+    with w._lock:
+        saved = (w._state, w._error_type, w._service)
+    try:
+        for state in (warmup_mod.IDLE, warmup_mod.WARMING,
+                      warmup_mod.READY, warmup_mod.FAILED):
+            with w._lock:
+                w._state = state
+                w._error_type = "KbStartupError" if state == warmup_mod.FAILED else None
+            assert _read_resource_text(CORPUS_URI) == expected, state
+    finally:
+        with w._lock:
+            w._state, w._error_type, w._service = saved

--- a/tests/kb/test_startup.py
+++ b/tests/kb/test_startup.py
@@ -24,7 +24,6 @@ pytest.importorskip("chromadb")
 pytest.importorskip("sentence_transformers")
 
 from _fixture_corpus import (
-    IMPORT_ONLY_SCRIPT,
     build_fixture_corpus,
     get_fixture_corpus,
     run_import_server,
@@ -41,6 +40,37 @@ assert str(resources[0].uri) == "kb://boomi-docs/corpus"
 print("ENABLED_OK")
 """
 
+# The heavy build is deferred, so `import server` must NOT import the ML stack;
+# forcing warmup via get() then performs the build and imports it. EAGER is off
+# so nothing kicks before the assertion (in-process import never kicks anyway).
+DEFERRED_IMPORT_SCRIPT = """
+import sys
+import server
+assert "chromadb" not in sys.modules, "chromadb imported at import (build not deferred)"
+assert "sentence_transformers" not in sys.modules, "sentence_transformers imported at import"
+svc = server._kb_warmup.get(wait_seconds=120)
+assert svc is not None, "KB warmup did not become ready"
+assert "chromadb" in sys.modules, "chromadb not imported after forcing warmup"
+res = server.search_boomi_docs(query="database connector")
+assert res["_success"] is True, res
+print("DEFERRED_IMPORT_OK")
+"""
+
+# Chunk-count mismatch is a HEAVY-build check, so it no longer crashes import —
+# it surfaces as a sanitized kb_unavailable from the warmed tool. The build gate
+# in Workstream C catches it before prod.
+CHUNK_MISMATCH_SCRIPT = """
+import server
+svc = server._kb_warmup.get(wait_seconds=120)
+assert svc is None, "expected warmup to fail on chunk-count mismatch"
+resp = server._kb_warmup.not_ready_response()
+assert resp["error"] == "kb_unavailable", resp
+assert resp["error_type"] == "KbStartupError", resp
+blob = repr(resp)
+assert "chunk count mismatch" not in blob, blob  # no raw detail leak to client
+print("CHUNK_MISMATCH_KB_UNAVAILABLE_OK")
+"""
+
 
 def test_enabled_boots_with_two_tools_and_one_resource():
     result = run_import_server(
@@ -54,11 +84,26 @@ def test_enabled_boots_with_two_tools_and_one_resource():
     assert "Boomi Docs KB registered" in result.stdout
 
 
-def test_chunk_count_mismatch_exits_with_clear_error(tmp_path):
+def test_import_defers_ml_then_warmup_builds_and_serves():
+    result = run_import_server(
+        DEFERRED_IMPORT_SCRIPT,
+        {"BOOMI_DOCS_ENABLED": "true",
+         "BOOMI_DOCS_WARMUP_EAGER": "false",
+         "BOOMI_DOCS_DB_PATH": get_fixture_corpus(),
+         "BOOMI_DOCS_COLLECTION": "boomi_docs"},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "DEFERRED_IMPORT_OK" in result.stdout
+
+
+def test_chunk_count_mismatch_surfaces_as_kb_unavailable(tmp_path):
     build_fixture_corpus(str(tmp_path), manifest_overrides={"chunk_count": 12345})
     result = run_import_server(
-        IMPORT_ONLY_SCRIPT,
-        {"BOOMI_DOCS_ENABLED": "true", "BOOMI_DOCS_DB_PATH": str(tmp_path)},
+        CHUNK_MISMATCH_SCRIPT,
+        {"BOOMI_DOCS_ENABLED": "true",
+         "BOOMI_DOCS_WARMUP_EAGER": "false",
+         "BOOMI_DOCS_DB_PATH": str(tmp_path)},
     )
-    assert result.returncode == 1
-    assert "chunk count mismatch" in (result.stdout + result.stderr)
+    # Import no longer crashes on a heavy-build failure; the tool degrades.
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "CHUNK_MISMATCH_KB_UNAVAILABLE_OK" in result.stdout

--- a/tests/kb/test_startup_no_deps.py
+++ b/tests/kb/test_startup_no_deps.py
@@ -17,6 +17,8 @@ for _p in (_HERE, _SRC, _ROOT):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+import json
+
 from _fixture_corpus import IMPORT_ONLY_SCRIPT, run_import_server
 
 DISABLED_SCRIPT = """
@@ -27,6 +29,64 @@ assert "sentence_transformers" not in sys.modules, "sentence_transformers import
 assert not hasattr(server, "search_boomi_docs"), "KB tool registered while disabled"
 print("DISABLED_OK")
 """
+
+# Deps-AGNOSTIC: with the KB enabled and a manifest that passes CHEAP validation,
+# `import server` registers the tools but must NOT import the ML stack — the
+# heavy build is deferred to KbWarmup. Holds whether or not chromadb is installed
+# because the build never runs here (no tool call). EAGER off so nothing kicks.
+DEFERRED_IMPORT_NO_ML_SCRIPT = """
+import sys
+import server
+assert hasattr(server, "search_boomi_docs"), "KB tool not registered while enabled"
+assert "chromadb" not in sys.modules, "chromadb imported at import (build not deferred)"
+assert "sentence_transformers" not in sys.modules, "sentence_transformers imported at import"
+print("DEFERRED_IMPORT_NO_ML_OK")
+"""
+
+# DETERMINISTIC missing-deps degradation: a meta_path finder raises
+# ModuleNotFoundError for the ML modules BEFORE `import server`, so the heavy
+# build hits the simulated ImportError regardless of what is installed. The tool
+# must return the SANITIZED kb_unavailable (generic message + coarse error_type,
+# no raw ImportError / requirements text).
+MISSING_DEPS_SCRIPT = """
+import sys
+import importlib.abc
+
+class _BlockML(importlib.abc.MetaPathFinder):
+    BLOCKED = ("chromadb", "sentence_transformers")
+    def find_spec(self, name, path, target=None):
+        if name.split(".")[0] in self.BLOCKED:
+            raise ModuleNotFoundError("simulated missing dependency: " + name)
+        return None
+
+sys.meta_path.insert(0, _BlockML())
+
+import server
+svc = server._kb_warmup.get(wait_seconds=30)
+assert svc is None, "warmup should fail when ML deps are missing"
+resp = server._kb_warmup.not_ready_response()
+assert resp["error"] == "kb_unavailable", resp
+assert resp["error_type"] == "KbStartupError", resp
+blob = repr(resp)
+assert "requirements-kb" not in blob, blob
+assert "chromadb" not in blob, blob
+print("MISSING_DEPS_KB_UNAVAILABLE_OK")
+"""
+
+
+def _write_cheap_valid_manifest(dir_path):
+    """Write a minimal manifest.json that passes validate_kb_manifest_cheap
+    (schema_version + collection_name + embedding_model) WITHOUT a Chroma corpus,
+    so the cheap import-time validation succeeds with no ML deps."""
+    manifest = {
+        "schema_version": "1",
+        "collection_name": "boomi_docs",
+        "embedding_model": "all-MiniLM-L6-v2",
+        "chunk_count": 1,
+        "build_timestamp": "2026-01-01T00:00:00Z",
+    }
+    with open(os.path.join(dir_path, "manifest.json"), "w", encoding="utf-8") as f:
+        json.dump(manifest, f)
 
 
 def test_disabled_boots_clean_without_ml_imports():
@@ -55,3 +115,27 @@ def test_corrupt_manifest_exits_with_clear_error(tmp_path):
     combined = result.stdout + result.stderr
     assert "Boomi Docs KB startup failed" in combined
     assert "not valid JSON" in combined
+
+
+def test_import_defers_ml_stack_when_enabled(tmp_path):
+    _write_cheap_valid_manifest(str(tmp_path))
+    result = run_import_server(
+        DEFERRED_IMPORT_NO_ML_SCRIPT,
+        {"BOOMI_DOCS_ENABLED": "true",
+         "BOOMI_DOCS_WARMUP_EAGER": "false",
+         "BOOMI_DOCS_DB_PATH": str(tmp_path)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "DEFERRED_IMPORT_NO_ML_OK" in result.stdout
+
+
+def test_missing_deps_degrade_to_sanitized_kb_unavailable(tmp_path):
+    _write_cheap_valid_manifest(str(tmp_path))
+    result = run_import_server(
+        MISSING_DEPS_SCRIPT,
+        {"BOOMI_DOCS_ENABLED": "true",
+         "BOOMI_DOCS_WARMUP_EAGER": "false",
+         "BOOMI_DOCS_DB_PATH": str(tmp_path)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "MISSING_DEPS_KB_UNAVAILABLE_OK" in result.stdout

--- a/tests/kb/test_tools_surface.py
+++ b/tests/kb/test_tools_surface.py
@@ -29,6 +29,13 @@ os.environ["BOOMI_DOCS_COLLECTION"] = "boomi_docs"
 
 import server  # noqa: E402
 
+# The heavy KB build is now deferred off the import path (KbWarmup). Force it
+# ready before the surface tests so the first call returns a real result rather
+# than a bounded warming_up. get() performs the kick() itself, so this works
+# regardless of the eager flag (which is only wired through server_http).
+_warmed = server._kb_warmup.get(wait_seconds=120)
+assert _warmed is not None, "KB warmup did not become ready for the surface tests"
+
 DB_PAGE = "https://help.boomi.com/docs/connectors/database"
 BIG_PAGE = "https://help.boomi.com/docs/processes/build-a-process"
 

--- a/tests/kb/test_warmup.py
+++ b/tests/kb/test_warmup.py
@@ -19,11 +19,7 @@ for _p in (_HERE, _SRC, _ROOT):
         sys.path.insert(0, _p)
 
 from boomi_mcp.kb.errors import KbStartupError
-from boomi_mcp.kb.warmup import (
-    KB_UNAVAILABLE_RETRY_AFTER,
-    WARMING_UP_RETRY_AFTER,
-    KbWarmup,
-)
+from boomi_mcp.kb.warmup import WARMING_UP_RETRY_AFTER, KbWarmup
 
 
 # --- warming_up -> ready ------------------------------------------------------
@@ -59,12 +55,15 @@ def test_failed_build_returns_sanitized_kb_unavailable():
     def builder(_bootstrap):
         raise KbStartupError("BOOMI_DOCS_DB_PATH does not exist: /app/kb/secret")
 
-    w = KbWarmup(bootstrap=None, builder=builder)
+    w = KbWarmup(bootstrap=None, builder=builder, retry_cooldown_seconds=30.0)
     assert w.get(wait_seconds=5) is None
     resp = w.not_ready_response()
     assert resp["error"] == "kb_unavailable"
     assert resp["error_type"] == "KbStartupError"
-    assert resp["retry_after_seconds"] == KB_UNAVAILABLE_RETRY_AFTER
+    # retry hint is derived from the (default 30s) cooldown — a positive int no
+    # larger than the configured cooldown.
+    assert isinstance(resp["retry_after_seconds"], int)
+    assert 1 <= resp["retry_after_seconds"] <= 30
     assert resp["message"] == (
         "Boomi Docs KB is temporarily unavailable. Please retry shortly."
     )
@@ -72,6 +71,33 @@ def test_failed_build_returns_sanitized_kb_unavailable():
     blob = repr(resp)
     assert "/app/kb/secret" not in blob
     assert "BOOMI_DOCS_DB_PATH" not in blob
+
+
+def test_kb_unavailable_retry_after_tracks_configured_cooldown():
+    """The failed-state retry hint must reflect the configured cooldown (and
+    shrink as it elapses), not a hard-coded default — otherwise a tuned-up
+    BOOMI_DOCS_WARMUP_RETRY_COOLDOWN leaves clients retrying into kb_unavailable
+    before a re-kick is even possible."""
+    clock = {"t": 1000.0}
+
+    def builder(_bootstrap):
+        raise KbStartupError("transient")
+
+    w = KbWarmup(
+        bootstrap=None,
+        builder=builder,
+        retry_cooldown_seconds=300.0,
+        time_fn=lambda: clock["t"],
+    )
+    assert w.get(wait_seconds=5) is None
+    # Right after the failure: the full 300s cooldown, not 30.
+    assert w.not_ready_response()["retry_after_seconds"] == 300
+    # Halfway through the cooldown: the REMAINING time.
+    clock["t"] = 1150.0
+    assert w.not_ready_response()["retry_after_seconds"] == 150
+    # Past the cooldown: clamped to "retry now" (>= 1).
+    clock["t"] = 2000.0
+    assert w.not_ready_response()["retry_after_seconds"] == 1
 
 
 # --- get() triggers kick() ----------------------------------------------------

--- a/tests/kb/test_warmup.py
+++ b/tests/kb/test_warmup.py
@@ -1,0 +1,207 @@
+"""Unit tests for KbWarmup — the deferred, thread-safe KB build state machine.
+
+Uses INJECTED fake builders only, so this module needs NO ML deps (no
+importorskip) and exercises the warmup logic deterministically: state-based
+responses, no-leak sanitization, get()-triggers-kick, single concurrent build,
+cooldown self-heal, and the daemon worker.
+"""
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = str(Path(_HERE).parents[1])
+_SRC = os.path.join(_ROOT, "src")
+for _p in (_HERE, _SRC, _ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from boomi_mcp.kb.errors import KbStartupError
+from boomi_mcp.kb.warmup import (
+    KB_UNAVAILABLE_RETRY_AFTER,
+    WARMING_UP_RETRY_AFTER,
+    KbWarmup,
+)
+
+
+# --- warming_up -> ready ------------------------------------------------------
+
+def test_warming_up_then_ready():
+    gate = threading.Event()
+    result = object()
+
+    def builder(_bootstrap):
+        gate.wait(timeout=5)
+        return result
+
+    w = KbWarmup(bootstrap=None, builder=builder)
+
+    # Build is in flight (blocked on the gate): a short wait yields None +
+    # the exact warming_up shape.
+    assert w.get(wait_seconds=0.1) is None
+    resp = w.not_ready_response()
+    assert resp == {
+        "_success": False,
+        "error": "warming_up",
+        "message": "Boomi Docs KB is still loading. Retry shortly.",
+        "retry_after_seconds": WARMING_UP_RETRY_AFTER,
+    }
+
+    gate.set()
+    assert w.get(wait_seconds=5) is result
+
+
+# --- failed build -> sanitized kb_unavailable --------------------------------
+
+def test_failed_build_returns_sanitized_kb_unavailable():
+    def builder(_bootstrap):
+        raise KbStartupError("BOOMI_DOCS_DB_PATH does not exist: /app/kb/secret")
+
+    w = KbWarmup(bootstrap=None, builder=builder)
+    assert w.get(wait_seconds=5) is None
+    resp = w.not_ready_response()
+    assert resp["error"] == "kb_unavailable"
+    assert resp["error_type"] == "KbStartupError"
+    assert resp["retry_after_seconds"] == KB_UNAVAILABLE_RETRY_AFTER
+    assert resp["message"] == (
+        "Boomi Docs KB is temporarily unavailable. Please retry shortly."
+    )
+    # No raw exception detail / internal path leaks into the client response.
+    blob = repr(resp)
+    assert "/app/kb/secret" not in blob
+    assert "BOOMI_DOCS_DB_PATH" not in blob
+
+
+# --- get() triggers kick() ----------------------------------------------------
+
+def test_get_triggers_build_without_explicit_kick():
+    calls = []
+    result = object()
+
+    def builder(_bootstrap):
+        calls.append(1)
+        return result
+
+    w = KbWarmup(bootstrap=None, builder=builder)
+    # No explicit kick(): get() must start the build itself (else an instance
+    # with eager off would return warming_up forever).
+    assert w.get(wait_seconds=5) is result
+    assert len(calls) == 1
+
+
+# --- one build across concurrent get()s --------------------------------------
+
+def test_concurrent_get_shares_single_build():
+    gate = threading.Event()
+    calls = []
+    result = object()
+
+    def builder(_bootstrap):
+        calls.append(1)
+        gate.wait(timeout=5)
+        return result
+
+    w = KbWarmup(bootstrap=None, builder=builder)
+    results = []
+
+    def worker():
+        results.append(w.get(wait_seconds=5))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    time.sleep(0.2)  # let all callers reach the wait
+    gate.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(calls) == 1, "expected a single in-flight build across concurrent get()"
+    assert results and all(r is result for r in results)
+
+
+# --- daemon worker ------------------------------------------------------------
+
+def test_worker_thread_is_daemon():
+    gate = threading.Event()
+
+    def builder(_bootstrap):
+        gate.wait(timeout=5)
+        return object()
+
+    w = KbWarmup(bootstrap=None, builder=builder)
+    w.kick()
+    try:
+        assert w._thread is not None
+        assert w._thread.daemon is True
+    finally:
+        gate.set()
+        w._thread.join(timeout=5)
+
+
+# --- state-based response: retry in flight is warming_up, not stale failure ---
+
+def test_retry_in_flight_reports_warming_up_not_stale_kb_unavailable():
+    clock = {"t": 1000.0}
+    gate2 = threading.Event()
+    state = {"attempt": 0}
+    result = object()
+
+    def builder(_bootstrap):
+        state["attempt"] += 1
+        if state["attempt"] == 1:
+            raise KbStartupError("transient")
+        gate2.wait(timeout=5)  # the retry build blocks so we can observe WARMING
+        return result
+
+    w = KbWarmup(
+        bootstrap=None,
+        builder=builder,
+        retry_cooldown_seconds=30.0,
+        time_fn=lambda: clock["t"],
+    )
+
+    # First build fails -> kb_unavailable.
+    assert w.get(wait_seconds=5) is None
+    assert w.not_ready_response()["error"] == "kb_unavailable"
+
+    # Advance past the cooldown; get() re-kicks a retry that is in flight.
+    clock["t"] += 31
+    assert w.get(wait_seconds=0.1) is None
+    # MUST be warming_up (state-based), NOT a stale kb_unavailable from _error.
+    assert w.not_ready_response()["error"] == "warming_up"
+
+    gate2.set()
+    assert w.get(wait_seconds=5) is result
+
+
+# --- self-heal after cooldown -------------------------------------------------
+
+def test_failed_build_self_heals_after_cooldown():
+    clock = {"t": 0.0}
+    state = {"attempt": 0}
+    result = object()
+
+    def builder(_bootstrap):
+        state["attempt"] += 1
+        if state["attempt"] == 1:
+            raise KbStartupError("transient")
+        return result
+
+    w = KbWarmup(
+        bootstrap=None,
+        builder=builder,
+        retry_cooldown_seconds=30.0,
+        time_fn=lambda: clock["t"],
+    )
+
+    # First attempt fails.
+    assert w.get(wait_seconds=5) is None
+    # Within cooldown: kick() is a no-op, no second build.
+    assert w.get(wait_seconds=5) is None
+    assert state["attempt"] == 1
+    # Past cooldown: the next get() re-attempts and succeeds.
+    clock["t"] = 31.0
+    assert w.get(wait_seconds=5) is result
+    assert state["attempt"] == 2

--- a/tests/test_first_request_warmup_hook.py
+++ b/tests/test_first_request_warmup_hook.py
@@ -1,0 +1,168 @@
+"""Tests for the first-/mcp-request eager KB warmup hook
+(server_http.FirstRequestWarmupMiddleware).
+
+The hook is an ASGI middleware composed INTO mcp.http_app(middleware=[...]); it
+runs after the auth provider parses the principal onto the scope but BEFORE the
+route-level 401, so its OWN auth-principal check is the safety boundary. These
+tests drive the middleware in isolation with synthetic ASGI scopes, a fake
+warmup that counts kick()s, and a stub downstream app — no MCP/auth stack or ML
+deps needed. There is no pytest-asyncio plugin in this repo, so async calls are
+driven via anyio.run from plain sync test functions (mirrors
+test_mcp_stream_guard.py).
+
+The end-to-end "unauthenticated /mcp POST -> 401 AND never kicked" assertion
+needs the full FastMCP auth stack and is a staging/integration check (see the
+plan's verification.warmup_auth_gate); here cases 6/7 prove the middleware's own
+auth gate, which is the actual safety boundary.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import anyio
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from server_http import FirstRequestWarmupMiddleware  # noqa: E402
+
+
+class _FakeWarmup:
+    """Records kick() calls; no real build."""
+
+    def __init__(self):
+        self.kicks = 0
+
+    def kick(self):
+        self.kicks += 1
+
+
+class _RecordingApp:
+    """Downstream ASGI app that records exactly what it was called with."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def __call__(self, scope, receive, send):
+        self.calls.append((scope, receive, send))
+
+
+class _AuthUser:
+    is_authenticated = True
+
+
+class _AnonUser:
+    is_authenticated = False
+
+
+async def _noop_receive():
+    return {"type": "http.request"}
+
+
+async def _noop_send(message):
+    return None
+
+
+def _drive(mw, scope, receive=None, send=None):
+    anyio.run(mw, scope, receive or _noop_receive, send or _noop_send)
+
+
+# --- (1) lifespan scope is passed through, never kicks -----------------------
+
+def test_lifespan_scope_does_not_kick_but_forwards():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    scope = {"type": "lifespan"}
+    _drive(mw, scope)
+    assert warmup.kicks == 0
+    assert len(app.calls) == 1
+    assert app.calls[0][0] is scope
+
+
+# --- (2) non-/mcp http paths never kick --------------------------------------
+
+def test_non_mcp_paths_do_not_kick():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    for path in ("/", "/authorize", "/token", "/web/login", "/static/app.js"):
+        _drive(mw, {"type": "http", "path": path, "user": _AuthUser()})
+    assert warmup.kicks == 0
+    assert len(app.calls) == 5  # all forwarded
+
+
+# --- (3) first authenticated /mcp request kicks exactly once -----------------
+
+def test_first_authenticated_mcp_request_kicks_once():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    for _ in range(5):
+        _drive(mw, {"type": "http", "path": "/mcp", "user": _AuthUser()})
+    assert warmup.kicks == 1  # _fired flag + kick idempotency
+    assert len(app.calls) == 5
+
+
+def test_trailing_slash_mcp_path_matches():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    _drive(mw, {"type": "http", "path": "/mcp/", "user": _AuthUser()})
+    assert warmup.kicks == 1
+
+
+def test_concurrent_first_requests_kick_at_most_once():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+
+    async def main():
+        async with anyio.create_task_group() as tg:
+            for _ in range(10):
+                scope = {"type": "http", "path": "/mcp", "user": _AuthUser()}
+                tg.start_soon(mw, scope, _noop_receive, _noop_send)
+
+    anyio.run(main)
+    assert warmup.kicks == 1
+    assert len(app.calls) == 10
+
+
+# --- (4) independent of the stream guard / session state ----------------------
+
+def test_hook_needs_only_app_and_warmup():
+    # Constructed with just (app, warmup) — no guard/session object — and works.
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    _drive(mw, {"type": "http", "path": "/mcp", "user": _AuthUser()})
+    assert warmup.kicks == 1
+
+
+# --- (5) scope/receive/send forwarded unchanged for all scopes ---------------
+
+def test_scope_receive_send_forwarded_unchanged():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    scope = {"type": "http", "path": "/mcp", "user": _AuthUser()}
+    _drive(mw, scope, _noop_receive, _noop_send)
+    fwd_scope, fwd_recv, fwd_send = app.calls[0]
+    assert fwd_scope is scope
+    assert fwd_recv is _noop_receive
+    assert fwd_send is _noop_send
+
+
+# --- (6) unauthenticated /mcp does NOT kick (auth gate) ----------------------
+
+def test_unauthenticated_mcp_does_not_kick():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    _drive(mw, {"type": "http", "path": "/mcp"})  # no user on scope
+    _drive(mw, {"type": "http", "path": "/mcp", "user": _AnonUser()})  # unauth user
+    assert warmup.kicks == 0
+    assert len(app.calls) == 2  # still forwarded downstream
+
+
+# --- (7) authenticated /mcp DOES kick (auth gate) ----------------------------
+
+def test_authenticated_mcp_kicks():
+    warmup, app = _FakeWarmup(), _RecordingApp()
+    mw = FirstRequestWarmupMiddleware(app, warmup)
+    _drive(mw, {"type": "http", "path": "/mcp", "user": _AuthUser()})
+    assert warmup.kicks == 1


### PR DESCRIPTION
## Problem

`search_boomi_docs` timed out for Claude Code on Cloud Run. Root cause: `build_kb_service()` ran at **module import** (`server.py`), and `server_http.py` imports `server` **before** `uvicorn.run()`. A cold instance therefore bound **no** socket during the multi-second Chroma-open + embedding-model load — the client timed out before `/mcp` existed.

## Fix (Workstreams A + C)

Make cold starts **non-fatal** without min-instances / always-on CPU (cost constraint preserved). The heavy KB build is deferred off the import path; the tools register immediately and the first call after a cold start returns a bounded structured response instead of hanging.

- **`kb/service.py`** — split into `validate_kb_manifest_cheap()` (pure stdlib, runs at import → preserves fail-fast for cheap-detectable corpus problems) + `build_kb_service_heavy()` (the heavy build, with per-phase timing logs). `build_kb_service()` composes them; unchanged signature.
- **`kb/warmup.py`** (new) — `KbWarmup` thread-safe state machine (idle→warming→ready|failed): idempotent `kick()`, `get(wait)`, state-based `not_ready_response()` (`warming_up` / `kb_unavailable`, sanitized — no path/detail leak), cooldown self-heal, log-based counters + stuck detection. `kb_unavailable` `retry_after_seconds` is derived from the remaining configured cooldown (ceil).
- **`server.py`** — cheap-validate at import; register tools/resource immediately; tool bodies use `get()`/`not_ready_response()` + sanitized `kb_query_error`; resource renders from the bootstrap manifest; `KB_INSTRUCTIONS` + docstring guidance. New env: `BOOMI_DOCS_WARMUP_WAIT_SECONDS` (5), `BOOMI_DOCS_WARMUP_EAGER` (true), `BOOMI_DOCS_WARMUP_RETRY_COOLDOWN` (30).
- **`server_http.py`** — `FirstRequestWarmupMiddleware`: eager kick on the first **authenticated** `/mcp` request, composed into `mcp.http_app(middleware=[...])` with its own auth-principal check (runs before the route-level 401).
- **`meta_tools.py` / `README.md`** — `warming_up` / `kb_unavailable` retry guidance + operator note.
- **`Dockerfile` (Workstream C)** — build-time `build_kb_service()` validation gate (offline flags inline) so a corrupt corpus / count mismatch / model-cache miss fails the **build**, not runtime; explicit `HF_HOME`/`SENTENCE_TRANSFORMERS_HOME` before the online preload; persisted `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE`; mode-agnostic TCP healthcheck (was `GET /mcp`).

## Verification

- **Unit**: 130 KB + first-request-hook + stream-guard + meta-tools tests pass.
- **Live QA** (`boomi-qa-tester`, `.fn()`): `warming_up`→real result, `read_boomi_doc_page`, resource warmup-state-independent, sanitized `kb_unavailable`/`kb_query_error` (no leak), cooldown-derived + ceil retry hint.
- **Codex review**: 2 findings fixed (cooldown-derived retry hint; ceil rounding), final review clean.
- **Docker build gate (real builds)**: positive `--build-arg KB_RELEASE_TAG=kb-13` SUCCEEDS (build-time `build_kb_service` resolves the model offline against the baked corpus, 12442 chunks); a corruption-injection variant (manifest `chunk_count` mutated) **FAILS at the validation RUN** with the count-mismatch error, not at runtime.
- **Cloud Run cold-start proof** (no-traffic tagged canary, 0% production traffic): a fresh cold instance bound `uvicorn` ~4s after the Python process started with the KB build registered as **deferred** and **no** heavy-build phases in the bind path; unauthenticated `/mcp` returned a prompt 401 and did **not** kick the warmup (auth gate verified on real infra).

## Not included (deferred)

- **Workstream B** (stateless transport — the stale-session 404 fix, `BOOMI_MCP_STATELESS_HTTP` / `BOOMI_MCP_JSON_RESPONSE`) is intentionally a separate staged rollout. Not in this PR.

## Operational note

The staging proof left an **inert** Cloud Run revision (`boomi-mcp-server-00215-qey`: no tag, 0% traffic — couldn't be hard-deleted as the latest-created revision; the next prod deploy supersedes it) and a throwaway AR image tag `kbwarmup-canary`. Production traffic is pinned 100% to the known-good `00213-phg`.