### PR TITLE
M9.7: Add safe existing-component edit workflow (pull -> structured patch -> diff -> push) (#97)

### DIFF
--- a/server.py
+++ b/server.py
@@ -291,6 +291,18 @@ except ImportError as e:
     print(f"[WARNING] Failed to import component analysis tools: {e}")
     analyze_component_action = None
 
+# --- Safe Existing-Component Edit Workflow (M9.7 / #97) ---
+try:
+    from boomi_mcp.categories.components.safe_edit_component import (
+        prepare_component_edit_action,
+        apply_component_edit_action,
+    )
+    print(f"[INFO] Safe component edit workflow loaded successfully")
+except ImportError as e:
+    print(f"[WARNING] Failed to import safe component edit workflow: {e}")
+    prepare_component_edit_action = None
+    apply_component_edit_action = None
+
 # --- Connector Tools ---
 try:
     from boomi_mcp.categories.components.connectors import manage_connector_action
@@ -1824,6 +1836,156 @@ if analyze_component_action:
             return {"_success": False, "error": str(e)}
 
     print("[INFO] Component analysis tool registered successfully (1 consolidated tool)")
+
+
+# --- Safe Existing-Component Edit Workflow MCP Tools (M9.7 / #97) ---
+if prepare_component_edit_action:
+    @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True})
+    @_kb_hint
+    def prepare_component_edit(
+        profile: str,
+        component_id: str,
+        patch: str,
+        max_diff_lines: int = 200,
+    ):
+        """
+        Preview a safe, structured edit to an existing component — READ-ONLY.
+
+        Phase 1 of the safe edit workflow (pull -> structured patch -> diff -> push).
+        Pulls the live component, applies a STRUCTURED patch in memory (no raw XML),
+        and returns a unified diff plus a confirmation_token. Performs NO Boomi
+        mutation. Pass the token (and the same patch) to apply_component_edit with
+        confirm_apply=true to commit.
+
+        Args:
+            profile: Boomi profile name (required)
+            component_id: Component to edit (required)
+            patch: JSON string with the structured edit. Shape:
+                {"component_type": "connector-settings",   # optional; defaults to live type
+                 "config": { ... structured fields ... },  # e.g. {"name": "Renamed"} or
+                                                            #      {"host": "db.internal", ...}
+                 "map_context": {"source_index": {...},     # only for transform.map body edits
+                                 "target_index": {...}}}
+                Metadata-only configs (name/component_name/description/folder_name/
+                folder_id) smart-merge the live root; other fields route through the
+                typed builder + #45/#50 preservation merge. Raw config.xml is rejected.
+            max_diff_lines: Cap the returned unified diff (default 200).
+
+        Returns:
+            diff, confirmation_token, base_version, update_mode, and no_change flag.
+        """
+        try:
+            patch_data = json.loads(patch)
+        except (json.JSONDecodeError, TypeError) as e:
+            return {"_success": False, "error": f"Invalid patch (must be a JSON string): {e}", "boomi_mutation": False}
+        if not isinstance(patch_data, dict):
+            return {"_success": False, "error": "patch must be a JSON object, not " + type(patch_data).__name__, "boomi_mutation": False}
+
+        try:
+            subject = get_current_user()
+            print(f"[INFO] prepare_component_edit called by user: {subject}, profile: {profile}, component: {component_id}")
+
+            creds = get_secret(subject, profile)
+
+            sdk_params = {
+                "account_id": creds["account_id"],
+                "username": creds["username"],
+                "password": creds["password"],
+                "timeout": 30000,
+            }
+            if creds.get("base_url"):
+                sdk_params["base_url"] = creds["base_url"]
+            sdk = Boomi(**sdk_params)
+
+            return prepare_component_edit_action(sdk, profile, component_id, patch_data, max_diff_lines)
+
+        except Exception as e:
+            print(f"[ERROR] Failed to prepare_component_edit: {e}")
+            return {"_success": False, "error": str(e), "boomi_mutation": False}
+
+    print("[INFO] Safe component edit (prepare) tool registered successfully")
+
+
+if apply_component_edit_action:
+    @mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True})
+    @_gotcha_hint
+    @_kb_hint
+    def apply_component_edit(
+        profile: str,
+        component_id: str,
+        patch: str,
+        confirmation_token: str,
+        confirm_apply: bool = False,
+        max_diff_lines: int = 200,
+    ):
+        """
+        Commit a previewed safe edit to an existing component — WRITES to Boomi.
+
+        Phase 2 of the safe edit workflow. Requires confirm_apply=true plus the
+        confirmation_token from prepare_component_edit and the SAME patch. Re-fetches
+        the component and ABORTS (no mutation) if it drifted since preview or the
+        patch changed; otherwise pushes the merged XML through the typed builder +
+        #45/#50 preservation path and returns a version comparison.
+
+        Args:
+            profile: Boomi profile name (required)
+            component_id: Component to edit (required)
+            patch: JSON string — the exact patch previewed by prepare_component_edit.
+            confirmation_token: The token returned by prepare_component_edit (required).
+            confirm_apply: Must be true to commit. Defaults to false (no-op gate).
+            max_diff_lines: Cap any fallback diff in the response (default 200).
+
+        Returns:
+            base_version, new_version, version_comparison, and update_mode.
+        """
+        try:
+            patch_data = json.loads(patch)
+        except (json.JSONDecodeError, TypeError) as e:
+            return {"_success": False, "error": f"Invalid patch (must be a JSON string): {e}", "boomi_mutation": False}
+        if not isinstance(patch_data, dict):
+            return {"_success": False, "error": "patch must be a JSON object, not " + type(patch_data).__name__, "boomi_mutation": False}
+
+        # Confirmation gate BEFORE any credential access (no creds touched on an
+        # unconfirmed call). The action layer re-checks as defense in depth.
+        if confirm_apply is not True:
+            return {
+                "_success": False,
+                "error_code": "COMPONENT_EDIT_CONFIRMATION_REQUIRED",
+                "error": "apply_component_edit requires confirm_apply=true.",
+                "field": "confirm_apply",
+                "hint": (
+                    "Run prepare_component_edit first, review the diff, then call "
+                    "apply_component_edit with the same patch, its confirmation_token, "
+                    "and confirm_apply=true."
+                ),
+                "boomi_mutation": False,
+            }
+
+        try:
+            subject = get_current_user()
+            print(f"[INFO] apply_component_edit called by user: {subject}, profile: {profile}, component: {component_id}")
+
+            creds = get_secret(subject, profile)
+
+            sdk_params = {
+                "account_id": creds["account_id"],
+                "username": creds["username"],
+                "password": creds["password"],
+                "timeout": 30000,
+            }
+            if creds.get("base_url"):
+                sdk_params["base_url"] = creds["base_url"]
+            sdk = Boomi(**sdk_params)
+
+            return apply_component_edit_action(
+                sdk, profile, component_id, patch_data, confirmation_token, confirm_apply, max_diff_lines
+            )
+
+        except Exception as e:
+            print(f"[ERROR] Failed to apply_component_edit: {e}")
+            return {"_success": False, "error": str(e), "boomi_mutation": False}
+
+    print("[INFO] Safe component edit (apply) tool registered successfully")
 
 
 # --- Connector MCP Tools ---

--- a/server.py
+++ b/server.py
@@ -1862,13 +1862,23 @@ if prepare_component_edit_action:
             component_id: Component to edit (required)
             patch: JSON string with the structured edit. Shape:
                 {"component_type": "connector-settings",   # optional; defaults to live type
-                 "config": { ... structured fields ... },  # e.g. {"name": "Renamed"} or
-                                                            #      {"host": "db.internal", ...}
+                 "config": { ... },
                  "map_context": {"source_index": {...},     # only for transform.map body edits
                                  "target_index": {...}}}
-                Metadata-only configs (name/component_name/description/folder_name/
-                folder_id) smart-merge the live root; other fields route through the
-                typed builder + #45/#50 preservation merge. Raw config.xml is rejected.
+                Two patch modes:
+                - METADATA (partial): config holds ONLY name/component_name/
+                  description/folder_name/folder_id. The live root is smart-merged
+                  in place — change just those fields, everything else preserved.
+                - BODY (full config): for any non-metadata field, config must be the
+                  COMPLETE structured config the typed builder consumes (same as
+                  build_integration's update path) — e.g. connector_type + all
+                  connection fields, or profile_type + its fields. The builder
+                  rebuilds its owned subtree; the #45/#50 merge preserves encrypted
+                  values + unknown XML. A body config is NOT a field-level delta:
+                  omitting the discriminator or a required builder field is rejected.
+                  Use get_schema_template(resource_type='component', operation='create',
+                  component_type=...) to see the full config a type needs.
+                Raw config.xml is rejected (use manage_component for full XML replace).
             max_diff_lines: Cap the returned unified diff (default 200).
 
         Returns:

--- a/src/boomi_mcp/categories/components/safe_edit_component.py
+++ b/src/boomi_mcp/categories/components/safe_edit_component.py
@@ -1,0 +1,581 @@
+"""Issue #97 (M9.7): safe existing-component edit workflow.
+
+A two-phase, pull -> structured patch -> diff -> push workflow that brings the
+Companion edit discipline into MCP without LLM-authored raw XML:
+
+- ``prepare_component_edit_action`` — READ-ONLY. Pull the live component, apply a
+  structured patch in memory (metadata smart-merge or builder + #45/#50
+  preservation merge), and return a unified diff plus a ``confirmation_token``
+  fingerprinting the base version, base XML, and patch. No Boomi mutation.
+- ``apply_component_edit_action`` — confirmed write. Requires ``confirm_apply``
+  and the token; re-fetches the component, ABORTS if it drifted since preview or
+  the patch changed, otherwise pushes the merged XML through the same builder +
+  preservation path, then returns a version comparison.
+
+Rollback / version restore is intentionally NOT part of this surface (deferred).
+
+The structured body path reuses ``integration_builder.build_structured_update_xml``
+(builder dispatch + ``PRESERVATION_POLICY``) and
+``component_update_preservation.merge_for_update`` so the previewed diff matches
+exactly what apply later pushes, and encrypted values / unknown XML survive.
+"""
+
+import base64
+import difflib
+import hashlib
+import json
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, Optional
+
+from boomi import Boomi
+
+from ._shared import (
+    component_get_xml,
+    set_description_element,
+    ComponentGetDeadlineExceeded,
+    component_get_deadline_envelope,
+    _extract_api_error_msg,
+)
+from .component_update_preservation import merge_for_update
+from .builders import BuilderValidationError
+from .analyze_component import compare_versions
+from ..integration_builder import build_structured_update_xml
+from ...models.integration_models import IntegrationComponentSpec
+
+
+# Patch ``config`` keys that route through the metadata smart-merge path (editing
+# the live root in place, mirroring ``manage_component.update_component``). A
+# patch whose config keys are all in this set never invokes a structured builder
+# (which would fail required-field validation); a patch with any OTHER key is a
+# body patch that goes through the builder + preservation merge.
+_METADATA_PATCH_KEYS = frozenset({
+    "name",
+    "component_name",
+    "description",
+    "folder_name",
+    "folder_id",
+})
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint / token helpers
+# ---------------------------------------------------------------------------
+
+def _canonical_json(value: Any) -> str:
+    """Deterministic JSON for hashing (sorted keys, compact separators)."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _make_confirmation_token(
+    component_id: str, version: int, base_xml_sha256: str, patch_sha256: str
+) -> str:
+    payload = _canonical_json({
+        "component_id": component_id,
+        "version": version,
+        "base_xml_sha256": base_xml_sha256,
+        "patch_sha256": patch_sha256,
+    })
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
+
+
+def _decode_confirmation_token(token: str) -> Dict[str, Any]:
+    raw = base64.urlsafe_b64decode(token.encode("ascii"))
+    data = json.loads(raw.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("confirmation_token payload is not an object")
+    return data
+
+
+def _normalize_for_diff(xml_text: str) -> str:
+    """Re-serialize XML through ElementTree so a diff against builder/merge output
+    (also ET-serialized) shows only logical changes, not namespace-prefix churn."""
+    return ET.tostring(ET.fromstring(xml_text), encoding="unicode")
+
+
+def _unified_diff(current_xml: str, merged_xml: str, max_diff_lines: int):
+    """Unified diff of normalized-current vs merged. Returns (lines, truncated)."""
+    try:
+        from_lines = _normalize_for_diff(current_xml).splitlines()
+    except ET.ParseError:
+        from_lines = current_xml.splitlines()
+    diff_lines = list(difflib.unified_diff(
+        from_lines,
+        merged_xml.splitlines(),
+        fromfile="current",
+        tofile="proposed",
+        lineterm="",
+    ))
+    truncated = False
+    if max_diff_lines and len(diff_lines) > max_diff_lines:
+        diff_lines = diff_lines[:max_diff_lines]
+        truncated = True
+    return diff_lines, truncated
+
+
+def _builder_validation_envelope(exc: BuilderValidationError) -> Dict[str, Any]:
+    envelope: Dict[str, Any] = {
+        "_success": False,
+        "error_code": exc.error_code,
+        "error": str(exc),
+        "field": exc.field,
+        "hint": exc.hint,
+    }
+    if getattr(exc, "details", None):
+        envelope["details"] = exc.details
+    return envelope
+
+
+# ---------------------------------------------------------------------------
+# Patch validation + merge (shared by prepare and apply so preview == write)
+# ---------------------------------------------------------------------------
+
+def _validate_patch_shape(patch: Any) -> Optional[Dict[str, Any]]:
+    """Return an error envelope if the patch is structurally invalid, else None."""
+    if not isinstance(patch, dict):
+        return {
+            "_success": False,
+            "error": "patch must be a JSON object with optional component_type, config, map_context.",
+            "field": "patch",
+        }
+    config = patch.get("config", {})
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        return {
+            "_success": False,
+            "error": "patch.config must be a JSON object of fields to change.",
+            "field": "config",
+        }
+    if config.get("xml"):
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_RAW_XML_UNSUPPORTED",
+            "error": (
+                "Raw XML patches are not supported by the safe edit workflow. "
+                "Use structured fields, or manage_component(action='update') with "
+                "config.xml as an explicit full-replacement escape hatch."
+            ),
+            "field": "config.xml",
+            "hint": (
+                "Set structured fields (e.g. host, base_url, query, name, "
+                "description) instead of raw XML so encrypted values and unknown "
+                "subtrees are preserved through the #45/#50 merge."
+            ),
+        }
+    map_context = patch.get("map_context")
+    if map_context is not None and not isinstance(map_context, dict):
+        return {
+            "_success": False,
+            "error": "patch.map_context must be a JSON object with source_index/target_index.",
+            "field": "map_context",
+        }
+    return None
+
+
+def _resolve_component_type(patch: Dict[str, Any], current: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve the effective component_type, defaulting to the pulled root type.
+
+    Returns {"_success": True, "component_type": str} or an error envelope.
+    """
+    pulled_type = (current.get("type") or "").strip()
+    supplied = patch.get("component_type")
+    if supplied is not None:
+        if not isinstance(supplied, str) or not supplied.strip():
+            return {
+                "_success": False,
+                "error": "patch.component_type must be a non-empty string when supplied.",
+                "field": "component_type",
+            }
+        if pulled_type and supplied.strip() != pulled_type:
+            return {
+                "_success": False,
+                "error_code": "COMPONENT_EDIT_TYPE_MISMATCH",
+                "error": (
+                    f"patch.component_type {supplied.strip()!r} does not match the "
+                    f"live component type {pulled_type!r}."
+                ),
+                "field": "component_type",
+                "hint": (
+                    "Omit component_type to use the live type, or correct it to "
+                    "match the component you are editing."
+                ),
+            }
+        component_type = supplied.strip()
+    else:
+        component_type = pulled_type
+    if not component_type:
+        return {
+            "_success": False,
+            "error": "Could not determine component_type from the patch or the live component.",
+            "field": "component_type",
+            "hint": "Pass patch.component_type explicitly (e.g. 'connector-settings').",
+        }
+    return {"_success": True, "component_type": component_type}
+
+
+def _compute_merged_xml(
+    boomi_client: Boomi,
+    current: Dict[str, Any],
+    component_type: str,
+    config: Dict[str, Any],
+    map_context: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build the merged XML for ``config`` against ``current`` — no push.
+
+    Returns {"_success": True, "merged_xml": str, "update_mode": str} or a
+    structured error envelope. Deterministic for a given (current, patch) so the
+    prepare preview and the apply write produce byte-identical XML.
+    """
+    current_xml = current["xml"]
+    config_keys = set(config.keys())
+
+    # Metadata-only patch -> smart-merge the live root in place (mirrors
+    # manage_component.update_component). Editing the parsed current tree
+    # preserves every other subtree, so encrypted values / unknown XML survive.
+    if config_keys and config_keys <= _METADATA_PATCH_KEYS:
+        try:
+            root = ET.fromstring(current_xml)
+        except ET.ParseError as exc:
+            return {
+                "_success": False,
+                "error": f"Live component XML could not be parsed: {exc}",
+                "field": "component_id",
+            }
+        new_name = config.get("name") or config.get("component_name")
+        if new_name:
+            root.set("name", new_name)
+        if config.get("folder_id"):
+            root.set("folderId", config["folder_id"])
+        if config.get("folder_name"):
+            root.set("folderName", config["folder_name"])
+        if "description" in config:
+            set_description_element(root, config["description"])
+        merged_xml = ET.tostring(root, encoding="unicode")
+        return {
+            "_success": True,
+            "merged_xml": merged_xml,
+            "update_mode": "metadata_smart_merge",
+        }
+
+    # Body patch -> structured builder + #45/#50 preservation merge.
+    comp = IntegrationComponentSpec(
+        key="safe_edit",
+        type=component_type,
+        action="update",
+        name=config.get("name") or config.get("component_name"),
+        config=dict(config),
+    )
+    payload = dict(config)
+    payload.setdefault("component_type", component_type)
+    if comp.name:
+        if component_type == "process":
+            payload.setdefault("name", comp.name)
+        elif component_type in ("connector-settings", "connector-action"):
+            payload.setdefault("component_name", comp.name)
+            payload.setdefault("name", comp.name)
+        else:
+            payload.setdefault("component_name", comp.name)
+
+    map_ctx = map_context or {}
+    prep = build_structured_update_xml(
+        boomi_client,
+        comp,
+        payload,
+        source_index=map_ctx.get("source_index"),
+        target_index=map_ctx.get("target_index"),
+    )
+    if not prep.get("_success"):
+        return prep
+    try:
+        merged_xml = merge_for_update(current_xml, prep["built_xml"], prep["policy"])
+    except BuilderValidationError as exc:
+        return _builder_validation_envelope(exc)
+    return {
+        "_success": True,
+        "merged_xml": merged_xml,
+        "update_mode": "read_merge_write",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — prepare (read-only)
+# ---------------------------------------------------------------------------
+
+def prepare_component_edit_action(
+    boomi_client: Boomi,
+    profile: str,
+    component_id: str,
+    patch: Dict[str, Any],
+    max_diff_lines: int = 200,
+) -> Dict[str, Any]:
+    """Read-only: pull the component, preview a structured patch, return diff + token.
+
+    Performs NO Boomi mutation. The returned ``confirmation_token`` must be
+    passed back to ``apply_component_edit_action`` to commit the change.
+    """
+    shape_error = _validate_patch_shape(patch)
+    if shape_error is not None:
+        shape_error.setdefault("boomi_mutation", False)
+        return shape_error
+    config = patch.get("config") or {}
+    if not config:
+        return {
+            "_success": False,
+            "error": "patch.config must contain at least one field to change.",
+            "field": "config",
+            "boomi_mutation": False,
+        }
+
+    try:
+        current = component_get_xml(boomi_client, component_id)
+    except ComponentGetDeadlineExceeded as exc:
+        return component_get_deadline_envelope(exc)
+    except Exception as exc:
+        return {
+            "_success": False,
+            "error": f"Failed to fetch component {component_id!r}: {_extract_api_error_msg(exc)}",
+            "exception_type": type(exc).__name__,
+            "boomi_mutation": False,
+        }
+
+    type_result = _resolve_component_type(patch, current)
+    if not type_result.get("_success"):
+        type_result.setdefault("boomi_mutation", False)
+        return type_result
+    component_type = type_result["component_type"]
+
+    merged = _compute_merged_xml(
+        boomi_client, current, component_type, config, patch.get("map_context")
+    )
+    if not merged.get("_success"):
+        merged.setdefault("boomi_mutation", False)
+        return merged
+    merged_xml = merged["merged_xml"]
+
+    base_version = current["version"]
+    base_xml_sha256 = _sha256(current["xml"])
+    patch_sha256 = _sha256(_canonical_json(patch))
+    token = _make_confirmation_token(
+        component_id, base_version, base_xml_sha256, patch_sha256
+    )
+    diff_lines, truncated = _unified_diff(current["xml"], merged_xml, max_diff_lines)
+
+    return {
+        "_success": True,
+        "read_only": True,
+        "boomi_mutation": False,
+        "component_id": component_id,
+        "component_type": component_type,
+        "base_version": base_version,
+        "update_mode": merged["update_mode"],
+        "preserves_unknown_xml": True,
+        "no_change": not diff_lines,
+        "diff": diff_lines,
+        "diff_truncated": truncated,
+        "confirmation_token": token,
+        "next_step": (
+            "Review the diff, then call apply_component_edit with the same patch, "
+            "this confirmation_token, and confirm_apply=true to commit."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — apply (confirmed write)
+# ---------------------------------------------------------------------------
+
+def apply_component_edit_action(
+    boomi_client: Boomi,
+    profile: str,
+    component_id: str,
+    patch: Dict[str, Any],
+    confirmation_token: str,
+    confirm_apply: bool = False,
+    max_diff_lines: int = 200,
+) -> Dict[str, Any]:
+    """Confirmed write: re-fetch, abort on drift, push the merged XML, compare versions.
+
+    Requires ``confirm_apply=True`` and the ``confirmation_token`` from prepare.
+    Aborts (no mutation) if the patch changed since prepare, the token is
+    malformed, or the live component drifted (version or XML hash) after preview.
+    """
+    if confirm_apply is not True:
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_CONFIRMATION_REQUIRED",
+            "error": "apply_component_edit requires confirm_apply=true.",
+            "field": "confirm_apply",
+            "hint": (
+                "Run prepare_component_edit first, review the diff, then call "
+                "apply_component_edit with the same patch, its confirmation_token, "
+                "and confirm_apply=true."
+            ),
+            "boomi_mutation": False,
+        }
+
+    shape_error = _validate_patch_shape(patch)
+    if shape_error is not None:
+        shape_error.setdefault("boomi_mutation", False)
+        return shape_error
+    config = patch.get("config") or {}
+    if not config:
+        return {
+            "_success": False,
+            "error": "patch.config must contain at least one field to change.",
+            "field": "config",
+            "boomi_mutation": False,
+        }
+
+    if not confirmation_token or not isinstance(confirmation_token, str):
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_TOKEN_INVALID",
+            "error": "confirmation_token is required; obtain it from prepare_component_edit.",
+            "field": "confirmation_token",
+            "boomi_mutation": False,
+        }
+    try:
+        token_data = _decode_confirmation_token(confirmation_token)
+    except Exception:
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_TOKEN_INVALID",
+            "error": "confirmation_token is malformed or not a value from prepare_component_edit.",
+            "field": "confirmation_token",
+            "hint": "Re-run prepare_component_edit to obtain a fresh token.",
+            "boomi_mutation": False,
+        }
+
+    if token_data.get("component_id") != component_id:
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_TOKEN_INVALID",
+            "error": (
+                "confirmation_token was issued for a different component "
+                f"({token_data.get('component_id')!r}, not {component_id!r})."
+            ),
+            "field": "confirmation_token",
+            "boomi_mutation": False,
+        }
+
+    patch_sha256 = _sha256(_canonical_json(patch))
+    if token_data.get("patch_sha256") != patch_sha256:
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_PATCH_MISMATCH",
+            "error": (
+                "The patch differs from the one previewed by prepare_component_edit. "
+                "Re-run prepare for the new patch and apply with its token."
+            ),
+            "field": "patch",
+            "boomi_mutation": False,
+        }
+
+    try:
+        current = component_get_xml(boomi_client, component_id)
+    except ComponentGetDeadlineExceeded as exc:
+        return component_get_deadline_envelope(exc)
+    except Exception as exc:
+        return {
+            "_success": False,
+            "error": f"Failed to fetch component {component_id!r}: {_extract_api_error_msg(exc)}",
+            "exception_type": type(exc).__name__,
+            "boomi_mutation": False,
+        }
+
+    base_version = current["version"]
+    base_xml_sha256 = _sha256(current["xml"])
+    if token_data.get("version") != base_version or token_data.get("base_xml_sha256") != base_xml_sha256:
+        return {
+            "_success": False,
+            "error_code": "COMPONENT_EDIT_DRIFT_DETECTED",
+            "error": (
+                "The component changed since prepare_component_edit previewed it; "
+                "the edit was aborted to avoid overwriting that change."
+            ),
+            "component_id": component_id,
+            "expected_version": token_data.get("version"),
+            "current_version": base_version,
+            "field": "component_id",
+            "hint": "Re-run prepare_component_edit to preview against the current version.",
+            "boomi_mutation": False,
+        }
+
+    type_result = _resolve_component_type(patch, current)
+    if not type_result.get("_success"):
+        type_result.setdefault("boomi_mutation", False)
+        return type_result
+    component_type = type_result["component_type"]
+
+    merged = _compute_merged_xml(
+        boomi_client, current, component_type, config, patch.get("map_context")
+    )
+    if not merged.get("_success"):
+        merged.setdefault("boomi_mutation", False)
+        return merged
+    merged_xml = merged["merged_xml"]
+
+    try:
+        boomi_client.component.update_component_raw(component_id, merged_xml)
+    except Exception as exc:
+        return {
+            "_success": False,
+            "error": f"Failed to push merged XML for component {component_id!r}: {_extract_api_error_msg(exc)}",
+            "exception_type": type(exc).__name__,
+            "boomi_mutation": False,
+        }
+
+    result: Dict[str, Any] = {
+        "_success": True,
+        "component_id": component_id,
+        "component_type": component_type,
+        "base_version": base_version,
+        "update_mode": merged["update_mode"],
+        "preserves_unknown_xml": True,
+        "boomi_mutation": True,
+        "message": f"Updated component {component_id!r} via {merged['update_mode']}.",
+    }
+
+    # Expose version comparison after write (acceptance criterion). Best-effort:
+    # a comparison failure does not undo the successful write.
+    try:
+        post = component_get_xml(boomi_client, component_id)
+        new_version = post["version"]
+        result["new_version"] = new_version
+        if new_version != base_version:
+            comparison = compare_versions(
+                boomi_client,
+                profile,
+                component_id,
+                {"source_version": base_version, "target_version": new_version},
+            )
+            if comparison.get("_success"):
+                result["version_comparison"] = comparison
+            else:
+                result["version_comparison_error"] = comparison.get("error")
+                result["diff"] = _unified_diff(current["xml"], merged_xml, max_diff_lines)[0]
+        else:
+            result["version_comparison_note"] = (
+                "Write produced no new version (no effective change); "
+                "no version comparison performed."
+            )
+    except ComponentGetDeadlineExceeded as exc:
+        result["version_comparison_error"] = str(exc)
+        result["diff"] = _unified_diff(current["xml"], merged_xml, max_diff_lines)[0]
+    except Exception as exc:
+        result["version_comparison_error"] = (
+            f"Post-write re-fetch failed: {_extract_api_error_msg(exc)}"
+        )
+        result["diff"] = _unified_diff(current["xml"], merged_xml, max_diff_lines)[0]
+
+    return result
+
+
+__all__ = [
+    "prepare_component_edit_action",
+    "apply_component_edit_action",
+]

--- a/src/boomi_mcp/categories/components/safe_edit_component.py
+++ b/src/boomi_mcp/categories/components/safe_edit_component.py
@@ -14,6 +14,17 @@ Companion edit discipline into MCP without LLM-authored raw XML:
 
 Rollback / version restore is intentionally NOT part of this surface (deferred).
 
+Two patch modes (``patch["config"]`` keys decide which):
+- METADATA (partial): only ``name``/``component_name``/``description``/
+  ``folder_name``/``folder_id`` — the live root is smart-merged in place, so the
+  caller changes just those fields and everything else is preserved verbatim.
+- BODY (full config): any other field routes through the typed builder, which
+  rebuilds its owned subtree from the config. The body config must therefore be
+  the COMPLETE structured config that builder consumes (the same contract as
+  ``build_integration``'s update path — e.g. a connector needs ``connector_type``
+  plus all connection fields). It is NOT a field-level delta; the #45/#50 merge
+  preserves encrypted values + unknown XML *outside* the builder's owned subtree.
+
 The structured body path reuses ``integration_builder.build_structured_update_xml``
 (builder dispatch + ``PRESERVATION_POLICY``) and
 ``component_update_preservation.merge_for_update`` so the previewed diff matches
@@ -73,6 +84,18 @@ def _sha256(text: str) -> str:
 def _make_confirmation_token(
     component_id: str, version: int, base_xml_sha256: str, patch_sha256: str
 ) -> str:
+    # The token is a stateless workflow + integrity FINGERPRINT, not an auth
+    # secret or capability grant: the caller of apply already holds the profile
+    # credentials and could mutate the component directly via manage_component, so
+    # the token is intentionally unsigned (no server-side secret / nonce store
+    # exists in this per-credential, potentially multi-instance MCP server — a
+    # per-process HMAC key would reject legitimate tokens across Cloud Run
+    # instances). The real safety guarantees are re-validated server-side at apply
+    # time regardless of the token's provenance: confirm_apply=true is the explicit
+    # confirmation gate, the version + base_xml_sha256 drift check re-fetches the
+    # live component and aborts on any change, and patch_sha256 binds the applied
+    # patch to the previewed one. A forged token can therefore never push a stale
+    # or mismatched write.
     payload = _canonical_json({
         "component_id": component_id,
         "version": version,
@@ -261,7 +284,14 @@ def _compute_merged_xml(
             "update_mode": "metadata_smart_merge",
         }
 
-    # Body patch -> structured builder + #45/#50 preservation merge.
+    # Body patch -> structured builder + #45/#50 preservation merge. The builder
+    # rebuilds its owned subtree from `config`, so `config` must be the COMPLETE
+    # structured config that builder requires (incl. the type discriminator such
+    # as connector_type / profile_type), not a field-level delta. An incomplete
+    # body config surfaces the builder's own structured error (missing field /
+    # UPDATE_PRESERVATION_POLICY_UNSUPPORTED with a hint to use metadata-only
+    # fields for a partial edit). merge_for_update then preserves everything
+    # outside the owned subtree (encrypted values, unknown XML).
     comp = IntegrationComponentSpec(
         key="safe_edit",
         type=component_type,

--- a/src/boomi_mcp/categories/integration_builder.py
+++ b/src/boomi_mcp/categories/integration_builder.py
@@ -1954,6 +1954,307 @@ def _apply_structured_update(
     }
 
 
+def _builder_validation_envelope(exc: BuilderValidationError) -> Dict[str, Any]:
+    """Structured error envelope for a BuilderValidationError raised by a build()."""
+    envelope: Dict[str, Any] = {
+        "_success": False,
+        "error_code": exc.error_code,
+        "error": str(exc),
+        "field": exc.field,
+        "hint": exc.hint,
+    }
+    if getattr(exc, "details", None):
+        envelope["details"] = exc.details
+    return envelope
+
+
+def build_structured_update_xml(
+    boomi_client: Boomi,
+    comp: IntegrationComponentSpec,
+    payload: Dict[str, Any],
+    *,
+    components_by_key: Optional[Dict[str, IntegrationComponentSpec]] = None,
+    source_index: Optional[Dict[str, Any]] = None,
+    target_index: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the desired UPDATE XML for a structured *body* patch and resolve
+    its preservation policy — READ-ONLY (no current-XML fetch, no push, no
+    create).
+
+    This is the build half of the read-merge-write update that
+    ``_apply_structured_update`` finishes. ``_execute_component`` (live apply)
+    and the #97 safe-edit prepare/apply workflow (no-mutation preview + confirmed
+    write) both call it so the same builder dispatch and the same
+    ``PRESERVATION_POLICY`` are used — a previewed diff therefore matches exactly
+    what apply later pushes.
+
+    Returns ``{"_success": True, "built_xml": str, "policy": PreservationPolicy}``
+    or a structured error envelope (the same envelopes ``_execute_component``
+    used to return inline). Callers MUST handle raw-XML rejection and the
+    metadata-only smart-merge route BEFORE calling this — a metadata-only payload
+    has no structured builder and would fail required-field validation here.
+
+    ``payload`` must already carry ``component_type`` / ``component_name`` exactly
+    as ``_execute_component`` prepares them. ``source_index`` / ``target_index``
+    override the transform.map field indexes (the safe-edit workflow supplies them
+    via ``map_context`` because there are no in-spec profile components to resolve
+    them from).
+    """
+    if comp.type == "process":
+        process_kind = str(
+            payload.get("process_kind") or payload.get("process_type") or ""
+        ).strip().lower()
+        if not process_kind:
+            return {
+                "_success": False,
+                "error_code": "PROCESS_KIND_REQUIRED",
+                "field": "config.process_kind",
+                "error": (
+                    "Process components must set config.process_kind; legacy "
+                    "freeform process JSON authoring has been removed."
+                ),
+                "hint": (
+                    "Set process_kind to one of "
+                    f"{sorted(PROCESS_FLOW_BUILDERS)}, or use manage_component "
+                    "with raw XML as an explicit escape hatch."
+                ),
+            }
+        builder_cls = get_process_flow_builder(process_kind)
+        if builder_cls is None:
+            return {
+                "_success": False,
+                "error_code": "PROCESS_KIND_UNSUPPORTED",
+                "error": (
+                    f"process_kind {process_kind!r} is not supported "
+                    f"by the structured process-flow builder."
+                ),
+                "field": "process_kind",
+                "hint": f"Supported process_kind values: {sorted(PROCESS_FLOW_BUILDERS)}.",
+            }
+        try:
+            built_xml = builder_cls.build(
+                payload,
+                name=payload.get("name") or comp.name,
+                folder_name=payload.get("folder_name"),
+            )
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(builder_cls, "PRESERVATION_POLICY", None),
+        }
+
+    if comp.type in ("connector-settings", "connector-action"):
+        rest_canonical = _resolve_rest_connector_type(payload.get("connector_type"))
+        if rest_canonical is not None:
+            payload["connector_type"] = rest_canonical
+        connector_type = payload.get("connector_type")
+        if connector_type:
+            try:
+                boomi_client.connector.get_connector(connector_type)
+            except Exception as exc:
+                return {
+                    "_success": False,
+                    "error": f"Connector type validation failed for '{connector_type}': {exc}",
+                }
+        if comp.type == "connector-settings":
+            builder_instance = get_connector_builder(connector_type or "")
+        else:
+            operation_mode = payload.get("operation_mode") or ""
+            builder_instance = get_connector_action_builder(
+                connector_type or "", operation_mode
+            )
+        if builder_instance is None:
+            return {
+                "_success": False,
+                "error_code": "UPDATE_PRESERVATION_POLICY_UNSUPPORTED",
+                "error": (
+                    f"No structured builder registered for connector "
+                    f"type {connector_type!r}"
+                    + (
+                        f" operation_mode {payload.get('operation_mode') or ''!r}"
+                        if comp.type == "connector-action"
+                        else ""
+                    )
+                    + ". Structured body-field updates require a builder."
+                ),
+                "field": (
+                    "operation_mode"
+                    if comp.type == "connector-action"
+                    else "connector_type"
+                ),
+                "hint": (
+                    "Use the raw-XML escape hatch (config.xml on "
+                    "manage_connector / manage_component) for unsupported "
+                    "connector types, or restrict the config to metadata-only "
+                    "fields (name, description, folder_name, folder_id) for a "
+                    "smart-merge update."
+                ),
+            }
+        try:
+            built_xml = builder_instance.build(**payload)
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(type(builder_instance), "PRESERVATION_POLICY", None),
+        }
+
+    if comp.type == "transform.function":
+        wrapper_cls = get_transform_function_wrapper_builder(comp.type)
+        if wrapper_cls is None:
+            return {
+                "_success": False,
+                "error_code": "SCRIPT_MAPPING_VALIDATION_FAILED",
+                "error": f"No TransformFunctionWrapperBuilder registered for {comp.type!r}.",
+                "field": "component_type",
+            }
+        try:
+            built_xml = wrapper_cls().build(**payload)
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(wrapper_cls, "PRESERVATION_POLICY", None),
+        }
+
+    if comp.type == "script.mapping":
+        builder_class = get_script_mapping_builder(comp.type)
+        if builder_class is None:
+            return {
+                "_success": False,
+                "error_code": "SCRIPT_MAPPING_VALIDATION_FAILED",
+                "error": f"No ScriptMappingBuilder registered for {comp.type!r}.",
+                "field": "component_type",
+            }
+        try:
+            built_xml = builder_class().build(**payload)
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(builder_class, "PRESERVATION_POLICY", None),
+        }
+
+    if comp.type == "profile.db":
+        profile_type = _safe_lower(payload.get("profile_type"))
+        builder_instance = get_profile_builder("profile.db", profile_type)
+        if builder_instance is None:
+            return {
+                "_success": False,
+                "error_code": "UNSUPPORTED_PROFILE_GENERATION_MODE",
+                "error": f"profile_type {profile_type!r} is not supported for profile.db.",
+                "field": "profile_type",
+            }
+        try:
+            built_xml = builder_instance.build(**payload)
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(type(builder_instance), "PRESERVATION_POLICY", None),
+        }
+
+    if comp.type in ("profile.json", "profile.xml"):
+        profile_type = _safe_lower(payload.get("profile_type"))
+        builder_instance = get_profile_builder(comp.type, profile_type)
+        if builder_instance is None:
+            return {
+                "_success": False,
+                "error_code": "UNSUPPORTED_PROFILE_GENERATION_MODE",
+                "error": f"profile_type {profile_type!r} is not supported for {comp.type}.",
+                "field": "profile_type",
+            }
+        try:
+            built_xml = builder_instance.build(**payload)
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(type(builder_instance), "PRESERVATION_POLICY", None),
+        }
+
+    if comp.type == "transform.map":
+        map_type = (payload.get("map_type") or "").lower()
+        map_builder_instance = get_map_builder(comp.type, map_type)
+        if map_builder_instance is None:
+            return {
+                "_success": False,
+                "error_code": "UNSUPPORTED_TRANSFORM_ROUTE",
+                "error": (
+                    f"map_type {map_type!r} is not supported for transform.map. "
+                    "Supported: direct, function, map_function, script, map_script."
+                ),
+                "field": "map_type",
+                "hint": (
+                    "Use map_type='direct' for profile-to-profile direct field "
+                    "mappings; map_type='function' for structured map-function "
+                    "primitives (#40); map_type='script' for in-map calls to "
+                    "reusable script.mapping components (#41)."
+                ),
+            }
+        s_index = source_index
+        t_index = target_index
+        if s_index is None or t_index is None:
+            raw_comp_config = comp.config or {}
+            if s_index is None:
+                s_index = resolve_map_profile_index(
+                    raw_comp_config.get("source_profile_id"), components_by_key
+                )
+            if t_index is None:
+                t_index = resolve_map_profile_index(
+                    raw_comp_config.get("target_profile_id"), components_by_key
+                )
+        if s_index is None or t_index is None:
+            return {
+                "_success": False,
+                "error_code": "MAP_PROFILE_INDEX_UNAVAILABLE",
+                "error": (
+                    "Cannot compute source/target field index for the map. "
+                    "Literal existing-profile UUIDs are not indexable in M2."
+                ),
+                "hint": (
+                    "Reference both source and target profiles as in-spec "
+                    "components via '$ref:KEY', or supply source_index / "
+                    "target_index via map_context."
+                ),
+            }
+        try:
+            built_xml = map_builder_instance.build(
+                source_index=s_index,
+                target_index=t_index,
+                **payload,
+            )
+        except BuilderValidationError as exc:
+            return _builder_validation_envelope(exc)
+        return {
+            "_success": True,
+            "built_xml": built_xml,
+            "policy": getattr(type(map_builder_instance), "PRESERVATION_POLICY", None),
+        }
+
+    return {
+        "_success": False,
+        "error_code": "UPDATE_PRESERVATION_POLICY_UNSUPPORTED",
+        "error": (
+            f"No structured update builder registered for component type "
+            f"{comp.type!r}."
+        ),
+        "field": "component_type",
+        "hint": (
+            "Use the raw-XML escape hatch (config.xml on manage_component) to "
+            "update via full XML replacement, or restrict the patch to "
+            "metadata-only fields for a smart-merge update."
+        ),
+    }
+
+
 def _execute_component(
     boomi_client: Boomi,
     profile: str,

--- a/src/boomi_mcp/categories/meta_tools.py
+++ b/src/boomi_mcp/categories/meta_tools.py
@@ -4146,26 +4146,29 @@ _COMPONENT_SAFE_EDIT = {
             "a field-level delta — only metadata fields support partial edits)."
         ),
     },
+    # A copy-pasteable, structurally-valid patch (the simplest case: a partial
+    # metadata edit; component_type is optional and defaults to the live type).
+    # For a body edit, see body_edit_example below.
     "patch_template": {
-        "metadata_partial_edit": {
-            "config": {
-                "name": "(optional) new name",
-                "description": "(optional) new description",
-                "folder_name": "(optional) target folder",
-                "folder_id": "(optional) target folder id",
-            },
+        "config": {
+            "name": "(metadata edit) optional new name",
+            "description": "(metadata edit) optional new description",
+            "folder_name": "(metadata edit) optional target folder",
+            "folder_id": "(metadata edit) optional target folder id",
         },
-        "structured_body_edit": {
-            "component_type": "(optional) defaults to the live component type",
-            "config": {
-                "connector_type": "database  # required discriminator for a connector body edit",
-                "component_name": "...  # plus EVERY field the typed builder requires",
-                "...": "full structured config (see get_schema_template operation='create' for the type)",
-            },
-            "map_context": {
-                "source_index": "(transform.map body edits only)",
-                "target_index": "(transform.map body edits only)",
-            },
+    },
+    # A separate, full-config body edit (NOT a field-level delta): config must be
+    # the complete config the typed builder for this component_type consumes.
+    "body_edit_example": {
+        "component_type": "connector-settings",
+        "config": {
+            "connector_type": "database  # required type discriminator",
+            "component_name": "...  # plus EVERY field the typed builder requires",
+            "...": "full structured config (see get_schema_template operation='create' for the type)",
+        },
+        "map_context": {
+            "source_index": "(transform.map body edits only)",
+            "target_index": "(transform.map body edits only)",
         },
     },
     "workflow": [

--- a/src/boomi_mcp/categories/meta_tools.py
+++ b/src/boomi_mcp/categories/meta_tools.py
@@ -4127,13 +4127,39 @@ _COMPONENT_SAFE_EDIT = {
         "rejected — use structured fields so encrypted values and unknown XML are "
         "preserved through the #45/#50 merge."
     ),
-    "patch_template": {
+    "patch_modes": {
+        "metadata_partial": (
+            "Partial edit: config holds ONLY metadata fields "
+            "(name/component_name, description, folder_name, folder_id). The live "
+            "root is smart-merged in place, so you change just those fields and "
+            "everything else is preserved verbatim."
+        ),
+        "structured_body": (
+            "Body edit: config must be the COMPLETE structured config the typed "
+            "builder for this component_type consumes (same contract as "
+            "build_integration's update path) — e.g. a connector edit needs "
+            "connector_type plus all required connection fields, a profile edit "
+            "needs profile_type plus its fields. The builder rebuilds its owned "
+            "subtree from that config; the #45/#50 merge then preserves encrypted "
+            "values and any unknown XML outside it. A body config that omits the "
+            "type discriminator or a required builder field is rejected (it is NOT "
+            "a field-level delta — only metadata fields support partial edits)."
+        ),
+    },
+    "patch_template_metadata": {
+        "config": {
+            "name": "(optional) new name",
+            "description": "(optional) new description",
+            "folder_name": "(optional) target folder",
+            "folder_id": "(optional) target folder id",
+        },
+    },
+    "patch_template_body": {
         "component_type": "(optional) defaults to the live component type",
         "config": {
-            "name": "(metadata) optional new name",
-            "description": "(metadata) optional new description",
-            "folder_name": "(metadata) optional target folder",
-            "host": "(example body field) structured field routed through the typed builder",
+            "connector_type": "database  # required discriminator for a connector body edit",
+            "component_name": "...  # plus EVERY field the typed builder requires",
+            "...": "full structured config (see get_schema_template operation='create' for the type)",
         },
         "map_context": {
             "source_index": "(transform.map body edits only)",
@@ -6933,18 +6959,25 @@ def list_capabilities_action(available_tools: set = None) -> Dict[str, Any]:
 
         "prepare_component_edit": {
             "category": "Components",
-            "description": "Safe edit phase 1 (M9.7): pull an existing component, preview a structured patch, return a diff + confirmation_token. Read-only — no Boomi mutation.",
+            "description": (
+                "Safe edit phase 1 (M9.7): pull an existing component, preview a structured patch, "
+                "return a diff + confirmation_token. Read-only — no Boomi mutation. Metadata fields "
+                "(name/description/folder) support partial edits; body edits require the full typed-builder "
+                "config (see get_schema_template operation='create')."
+            ),
             "actions": ["prepare"],
             "read_only": True,
             "parameters": {
                 "profile": "str (required)",
                 "component_id": "str (required)",
-                "patch": "JSON str (required) — {\"component_type\"?, \"config\": {...}, \"map_context\"?}; raw config.xml is rejected",
+                "patch": "JSON str (required) — {\"component_type\"?, \"config\": {...}, \"map_context\"?}; metadata config = partial edit, body config = full builder config; raw config.xml is rejected",
                 "max_diff_lines": "int (optional, default 200)",
             },
             "examples": [
-                'prepare_component_edit(profile="prod", component_id="abc-123", patch=\'{"config": {"name": "Renamed"}}\')',
-                'prepare_component_edit(profile="prod", component_id="abc-123", patch=\'{"component_type": "connector-settings", "config": {"host": "db.internal"}}\')',
+                '# Partial metadata edit:',
+                'prepare_component_edit(profile="prod", component_id="abc-123", patch=\'{"config": {"name": "Renamed", "description": "updated"}}\')',
+                '# Body edit needs the FULL typed-builder config (connector_type + all fields), not a single field:',
+                'prepare_component_edit(profile="prod", component_id="abc-123", patch=\'{"component_type": "connector-settings", "config": {"connector_type": "database", "component_name": "...", "driver_id": "mysql", "host": "db.internal", "dbname": "app", "auth_mode": "username_password", "username": "svc", "credential_ref": "..."}}\')',
             ],
         },
         "apply_component_edit": {

--- a/src/boomi_mcp/categories/meta_tools.py
+++ b/src/boomi_mcp/categories/meta_tools.py
@@ -4146,24 +4146,26 @@ _COMPONENT_SAFE_EDIT = {
             "a field-level delta — only metadata fields support partial edits)."
         ),
     },
-    "patch_template_metadata": {
-        "config": {
-            "name": "(optional) new name",
-            "description": "(optional) new description",
-            "folder_name": "(optional) target folder",
-            "folder_id": "(optional) target folder id",
+    "patch_template": {
+        "metadata_partial_edit": {
+            "config": {
+                "name": "(optional) new name",
+                "description": "(optional) new description",
+                "folder_name": "(optional) target folder",
+                "folder_id": "(optional) target folder id",
+            },
         },
-    },
-    "patch_template_body": {
-        "component_type": "(optional) defaults to the live component type",
-        "config": {
-            "connector_type": "database  # required discriminator for a connector body edit",
-            "component_name": "...  # plus EVERY field the typed builder requires",
-            "...": "full structured config (see get_schema_template operation='create' for the type)",
-        },
-        "map_context": {
-            "source_index": "(transform.map body edits only)",
-            "target_index": "(transform.map body edits only)",
+        "structured_body_edit": {
+            "component_type": "(optional) defaults to the live component type",
+            "config": {
+                "connector_type": "database  # required discriminator for a connector body edit",
+                "component_name": "...  # plus EVERY field the typed builder requires",
+                "...": "full structured config (see get_schema_template operation='create' for the type)",
+            },
+            "map_context": {
+                "source_index": "(transform.map body edits only)",
+                "target_index": "(transform.map body edits only)",
+            },
         },
     },
     "workflow": [

--- a/src/boomi_mcp/categories/meta_tools.py
+++ b/src/boomi_mcp/categories/meta_tools.py
@@ -701,6 +701,8 @@ _COMPONENT_OVERVIEW = {
         "query_components": ["list", "get", "search", "bulk_get"],
         "manage_component": ["create", "update", "clone", "delete"],
         "analyze_component": ["where_used", "dependencies", "compare_versions", "merge"],
+        "prepare_component_edit": ["prepare"],
+        "apply_component_edit": ["apply"],
     },
     "component_types": [
         "process", "processproperty", "processroute",
@@ -4111,6 +4113,50 @@ _COMPONENT_COMPARE = {
     "hint": "Version numbers are integers starting at 1. Use query_components get to see current version.",
 }
 
+_COMPONENT_SAFE_EDIT = {
+    "resource_type": "component",
+    "operation": "safe_edit",
+    "tools": [
+        "prepare_component_edit (read-only preview)",
+        "apply_component_edit (confirmed write)",
+    ],
+    "summary": (
+        "Two-phase safe edit of an existing component (M9.7): pull -> structured "
+        "patch -> diff -> push. Preview is read-only; the write requires explicit "
+        "confirmation and aborts if the component drifted since preview. Raw XML is "
+        "rejected — use structured fields so encrypted values and unknown XML are "
+        "preserved through the #45/#50 merge."
+    ),
+    "patch_template": {
+        "component_type": "(optional) defaults to the live component type",
+        "config": {
+            "name": "(metadata) optional new name",
+            "description": "(metadata) optional new description",
+            "folder_name": "(metadata) optional target folder",
+            "host": "(example body field) structured field routed through the typed builder",
+        },
+        "map_context": {
+            "source_index": "(transform.map body edits only)",
+            "target_index": "(transform.map body edits only)",
+        },
+    },
+    "workflow": [
+        "1. query_components(action='get', component_id=...) — inspect the live component",
+        "2. prepare_component_edit(profile, component_id, patch) — review diff + confirmation_token (no mutation)",
+        "3. apply_component_edit(profile, component_id, patch, confirmation_token, confirm_apply=true) — commit",
+        "4. analyze_component(action='compare_versions', ...) — confirm what changed",
+    ],
+    "error_codes": [
+        "COMPONENT_EDIT_RAW_XML_UNSUPPORTED",
+        "COMPONENT_EDIT_CONFIRMATION_REQUIRED",
+        "COMPONENT_EDIT_TOKEN_INVALID",
+        "COMPONENT_EDIT_PATCH_MISMATCH",
+        "COMPONENT_EDIT_DRIFT_DETECTED",
+        "COMPONENT_EDIT_TYPE_MISMATCH",
+    ],
+    "note": "Rollback / version restore stays deferred (not part of this surface).",
+}
+
 
 # ============================================================================
 # Organization Templates
@@ -4801,6 +4847,15 @@ def _authoring_workflow_sequences() -> Dict[str, Any]:
                 "2. query_components(action='list', config='{\"type\": \"process\"}') → list processes",
                 "3. query_components(action='get', component_id='...') → get details",
                 "4. analyze_component(action='where_used', component_id='...') → find dependencies",
+            ],
+        },
+        "safe_edit_existing_component": {
+            "description": "Safely edit an existing component (M9.7): pull → structured patch → diff → confirmed push, preserving encrypted values and unknown XML; aborts if the component drifted since preview.",
+            "steps": [
+                "1. query_components(action='get', component_id='...') → inspect the live component and its current version",
+                "2. prepare_component_edit(profile='...', component_id='...', patch='{\"config\": {\"name\": \"...\"}}') → review the diff and capture confirmation_token (read-only, no Boomi mutation)",
+                "3. apply_component_edit(profile='...', component_id='...', patch='<same patch>', confirmation_token='<token>', confirm_apply=true) → commit the merged XML (aborts on drift / patch change)",
+                "4. analyze_component(action='compare_versions', component_id='...', config='{\"source_version\": <base>, \"target_version\": <new>}') → confirm exactly what changed",
             ],
         },
         "create_and_deploy_process": {
@@ -5954,10 +6009,13 @@ def _get_component_template(operation=None, component_type=None, protocol=None, 
     if operation == "compare_versions":
         return {"_success": True, **_COMPONENT_COMPARE}
 
+    if operation == "safe_edit":
+        return {"_success": True, **_COMPONENT_SAFE_EDIT}
+
     return {
         "_success": False,
         "error": f"Unknown component operation: {operation}",
-        "valid_operations": ["create", "search", "clone", "compare_versions"],
+        "valid_operations": ["create", "search", "clone", "compare_versions", "safe_edit"],
     }
 
 
@@ -6870,6 +6928,40 @@ def list_capabilities_action(available_tools: set = None) -> Dict[str, Any]:
                 "compare_component_versions.py",
                 "component_diff.py",
                 "merge_components.py",
+            ],
+        },
+
+        "prepare_component_edit": {
+            "category": "Components",
+            "description": "Safe edit phase 1 (M9.7): pull an existing component, preview a structured patch, return a diff + confirmation_token. Read-only — no Boomi mutation.",
+            "actions": ["prepare"],
+            "read_only": True,
+            "parameters": {
+                "profile": "str (required)",
+                "component_id": "str (required)",
+                "patch": "JSON str (required) — {\"component_type\"?, \"config\": {...}, \"map_context\"?}; raw config.xml is rejected",
+                "max_diff_lines": "int (optional, default 200)",
+            },
+            "examples": [
+                'prepare_component_edit(profile="prod", component_id="abc-123", patch=\'{"config": {"name": "Renamed"}}\')',
+                'prepare_component_edit(profile="prod", component_id="abc-123", patch=\'{"component_type": "connector-settings", "config": {"host": "db.internal"}}\')',
+            ],
+        },
+        "apply_component_edit": {
+            "category": "Components",
+            "description": "Safe edit phase 2 (M9.7): commit a previewed structured patch with the confirmation_token. Requires confirm_apply=true; aborts if the component drifted since preview. Preserves encrypted values / unknown XML.",
+            "actions": ["apply"],
+            "read_only": False,
+            "parameters": {
+                "profile": "str (required)",
+                "component_id": "str (required)",
+                "patch": "JSON str (required) — the same patch previewed by prepare_component_edit",
+                "confirmation_token": "str (required) — from prepare_component_edit",
+                "confirm_apply": "bool (required to commit; defaults false)",
+                "max_diff_lines": "int (optional, default 200)",
+            },
+            "examples": [
+                'apply_component_edit(profile="prod", component_id="abc-123", patch=\'{"config": {"name": "Renamed"}}\', confirmation_token="<token>", confirm_apply=true)',
             ],
         },
 

--- a/src/boomi_mcp/errors.py
+++ b/src/boomi_mcp/errors.py
@@ -41,6 +41,14 @@ SCHEMA_NAME_UNSUPPORTED = "SCHEMA_NAME_UNSUPPORTED"
 SCHEMA_LOOKUP_FAILED = "SCHEMA_LOOKUP_FAILED"
 WORKFLOW_SEQUENCE_NOT_FOUND = "WORKFLOW_SEQUENCE_NOT_FOUND"
 
+# --- Safe existing-component edit workflow (M9.7 / issue #97) -----------------
+COMPONENT_EDIT_RAW_XML_UNSUPPORTED = "COMPONENT_EDIT_RAW_XML_UNSUPPORTED"
+COMPONENT_EDIT_CONFIRMATION_REQUIRED = "COMPONENT_EDIT_CONFIRMATION_REQUIRED"
+COMPONENT_EDIT_TOKEN_INVALID = "COMPONENT_EDIT_TOKEN_INVALID"
+COMPONENT_EDIT_PATCH_MISMATCH = "COMPONENT_EDIT_PATCH_MISMATCH"
+COMPONENT_EDIT_DRIFT_DETECTED = "COMPONENT_EDIT_DRIFT_DETECTED"
+COMPONENT_EDIT_TYPE_MISMATCH = "COMPONENT_EDIT_TYPE_MISMATCH"
+
 
 @dataclass(frozen=True)
 class ErrorCodeSpec:
@@ -170,6 +178,48 @@ ERROR_TAXONOMY: Dict[str, ErrorCodeSpec] = {
             retryable=False,
             summary="Unknown workflow sequence name; see valid_workflows.",
             owner="#10",
+        ),
+        ErrorCodeSpec(
+            code=COMPONENT_EDIT_RAW_XML_UNSUPPORTED,
+            category="component_edit",
+            retryable=False,
+            summary="Safe edit rejects raw XML patches; use structured fields or manage_component config.xml.",
+            owner="#97",
+        ),
+        ErrorCodeSpec(
+            code=COMPONENT_EDIT_CONFIRMATION_REQUIRED,
+            category="component_edit",
+            retryable=False,
+            summary="apply_component_edit needs confirm_apply=true plus a prepare confirmation_token.",
+            owner="#97",
+        ),
+        ErrorCodeSpec(
+            code=COMPONENT_EDIT_TOKEN_INVALID,
+            category="component_edit",
+            retryable=False,
+            summary="confirmation_token is missing, malformed, or issued for another component.",
+            owner="#97",
+        ),
+        ErrorCodeSpec(
+            code=COMPONENT_EDIT_PATCH_MISMATCH,
+            category="component_edit",
+            retryable=False,
+            summary="The applied patch differs from the previewed one; re-run prepare for the new patch.",
+            owner="#97",
+        ),
+        ErrorCodeSpec(
+            code=COMPONENT_EDIT_DRIFT_DETECTED,
+            category="component_edit",
+            retryable=False,
+            summary="The component changed since preview; the edit was aborted. Re-run prepare.",
+            owner="#97",
+        ),
+        ErrorCodeSpec(
+            code=COMPONENT_EDIT_TYPE_MISMATCH,
+            category="component_edit",
+            retryable=False,
+            summary="patch.component_type does not match the live component type.",
+            owner="#97",
         ),
     )
 }

--- a/tests/test_component_safe_edit.py
+++ b/tests/test_component_safe_edit.py
@@ -1,0 +1,335 @@
+"""Action-level tests for the M9.7 safe existing-component edit workflow (#97).
+
+Exercises prepare_component_edit_action / apply_component_edit_action against a
+fake Boomi client: read-only preview, confirmation gate, raw-XML rejection,
+encrypted/unknown XML preservation, drift + patch-mismatch aborts, and the
+post-write version comparison.
+"""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+_src = str(Path(__file__).resolve().parent.parent / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from boomi_mcp.categories.components import safe_edit_component
+from boomi_mcp.categories.components.safe_edit_component import (
+    prepare_component_edit_action,
+    apply_component_edit_action,
+)
+from boomi_mcp.categories.components.component_update_preservation import (
+    OwnedPath,
+    PreservationPolicy,
+)
+
+NS = {"bns": "http://api.platform.boomi.com/"}
+COMPONENT_ID = "abc-123"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + fake client
+# ---------------------------------------------------------------------------
+
+_CURRENT_DB_CONN = (
+    '<bns:Component xmlns:bns="http://api.platform.boomi.com/" '
+    'type="connector-settings" subType="database" name="conn-old" '
+    'folderId="42" futureFlag="opaque-value">'
+    '<bns:encryptedValues>'
+    '<bns:encryptedValue path="//DatabaseConnectionSettings/@password" isSet="true"/>'
+    '</bns:encryptedValues>'
+    '<bns:description>old-desc</bns:description>'
+    '<bns:object>'
+    '<DatabaseConnectionSettings xmlns="" dbname="olddb" host="old.example.com"/>'
+    '<UnknownSibling xmlns="" id="must-survive"/>'
+    '</bns:object>'
+    '</bns:Component>'
+)
+
+_DESIRED_DB_CONN = (
+    '<bns:Component xmlns:bns="http://api.platform.boomi.com/" '
+    'type="connector-settings" subType="database" name="conn-renamed">'
+    '<bns:encryptedValues/>'
+    '<bns:object>'
+    '<DatabaseConnectionSettings xmlns="" dbname="newdb" host="db.internal"/>'
+    '</bns:object>'
+    '</bns:Component>'
+)
+
+_DB_POLICY = PreservationPolicy(
+    component_type="connector-settings",
+    subtype="database",
+    owned_root_attrs=("name", "folderId"),
+    owned_paths=(OwnedPath(path="bns:object/DatabaseConnectionSettings"),),
+)
+
+_CURRENT_MAP = (
+    '<bns:Component xmlns:bns="http://api.platform.boomi.com/" '
+    'type="transform.map" name="m-old">'
+    '<bns:object><Map xmlns=""/></bns:object>'
+    '</bns:Component>'
+)
+
+
+def _with_version(xml_text: str, version: int) -> str:
+    root = ET.fromstring(xml_text)
+    root.set("version", str(version))
+    return ET.tostring(root, encoding="unicode")
+
+
+class _FakeComponentApi:
+    def __init__(self, xml_text: str, version: int = 3):
+        self._xml = xml_text
+        self._version = version
+        self.pushed = []
+
+    def get_component(self, component_id):
+        return _with_version(self._xml, self._version)
+
+    def update_component_raw(self, component_id, xml_text):
+        self.pushed.append((component_id, xml_text))
+        self._xml = xml_text
+        self._version += 1
+        return b"<updated/>"
+
+
+class _FakeConnectorApi:
+    def __init__(self):
+        self.calls = []
+
+    def get_connector(self, connector_type):
+        self.calls.append(connector_type)
+        return {"type": connector_type}
+
+
+class _FakeClient:
+    def __init__(self, xml_text: str = _CURRENT_DB_CONN, version: int = 3):
+        self.component = _FakeComponentApi(xml_text, version)
+        self.connector = _FakeConnectorApi()
+
+
+def _spy_compare(monkeypatch):
+    calls = []
+
+    def _fake_compare(boomi_client, profile, component_id, config):
+        calls.append(config)
+        return {"_success": True, "diff": {"changed": True}}
+
+    monkeypatch.setattr(safe_edit_component, "compare_versions", _fake_compare)
+    return calls
+
+
+def _prepare_then_token(client, patch):
+    prep = prepare_component_edit_action(client, "prof", COMPONENT_ID, patch)
+    assert prep["_success"] is True, prep
+    return prep["confirmation_token"]
+
+
+# ---------------------------------------------------------------------------
+# Read-only preview
+# ---------------------------------------------------------------------------
+
+def test_prepare_is_read_only_no_mutation():
+    client = _FakeClient()
+    prep = prepare_component_edit_action(
+        client, "prof", COMPONENT_ID, {"config": {"name": "conn-new"}}
+    )
+    assert prep["_success"] is True
+    assert prep["read_only"] is True
+    assert prep["boomi_mutation"] is False
+    assert prep["confirmation_token"]
+    assert prep["diff"]  # a rename produces a diff
+    assert client.component.pushed == []  # no write happened
+
+
+def test_prepare_no_change_flag_when_patch_is_noop():
+    client = _FakeClient()
+    # Re-set the existing name -> merged XML equals current -> empty diff.
+    prep = prepare_component_edit_action(
+        client, "prof", COMPONENT_ID, {"config": {"name": "conn-old"}}
+    )
+    assert prep["_success"] is True
+    assert prep["no_change"] is True
+    assert prep["diff"] == []
+    assert client.component.pushed == []
+
+
+# ---------------------------------------------------------------------------
+# Confirmation gate + raw XML rejection
+# ---------------------------------------------------------------------------
+
+def test_apply_requires_confirmation():
+    client = _FakeClient()
+    token = _prepare_then_token(client, {"config": {"name": "conn-new"}})
+    res = apply_component_edit_action(
+        client, "prof", COMPONENT_ID,
+        {"config": {"name": "conn-new"}}, token, confirm_apply=False,
+    )
+    assert res["_success"] is False
+    assert res["error_code"] == "COMPONENT_EDIT_CONFIRMATION_REQUIRED"
+    assert res["boomi_mutation"] is False
+    assert client.component.pushed == []
+
+
+@pytest.mark.parametrize("action", [prepare_component_edit_action, apply_component_edit_action])
+def test_raw_xml_patch_rejected(action):
+    client = _FakeClient()
+    patch = {"config": {"xml": "<Component/>"}}
+    if action is prepare_component_edit_action:
+        res = action(client, "prof", COMPONENT_ID, patch)
+    else:
+        res = action(client, "prof", COMPONENT_ID, patch, "tok", confirm_apply=True)
+    assert res["_success"] is False
+    assert res["error_code"] == "COMPONENT_EDIT_RAW_XML_UNSUPPORTED"
+    assert client.component.pushed == []
+
+
+def test_type_mismatch_rejected():
+    client = _FakeClient()
+    prep = prepare_component_edit_action(
+        client, "prof", COMPONENT_ID,
+        {"component_type": "process", "config": {"name": "x"}},
+    )
+    assert prep["_success"] is False
+    assert prep["error_code"] == "COMPONENT_EDIT_TYPE_MISMATCH"
+
+
+# ---------------------------------------------------------------------------
+# Metadata smart-merge: preserves everything, applies, compares versions
+# ---------------------------------------------------------------------------
+
+def test_metadata_apply_preserves_and_compares(monkeypatch):
+    calls = _spy_compare(monkeypatch)
+    client = _FakeClient()
+    patch = {"config": {"name": "conn-renamed", "description": "new-desc"}}
+    token = _prepare_then_token(client, patch)
+
+    res = apply_component_edit_action(
+        client, "prof", COMPONENT_ID, patch, token, confirm_apply=True
+    )
+    assert res["_success"] is True
+    assert res["boomi_mutation"] is True
+    assert res["update_mode"] == "metadata_smart_merge"
+    assert res["base_version"] == 3
+    assert res["new_version"] == 4
+
+    # version comparison was requested with base + post-write versions.
+    assert calls == [{"source_version": 3, "target_version": 4}]
+    assert "version_comparison" in res
+
+    # The pushed XML renamed the component but kept the encrypted secret and the
+    # unknown sibling.
+    pushed_id, pushed_xml = client.component.pushed[-1]
+    assert pushed_id == COMPONENT_ID
+    root = ET.fromstring(pushed_xml)
+    assert root.get("name") == "conn-renamed"
+    ev = root.find("bns:encryptedValues/bns:encryptedValue", NS)
+    assert ev is not None and ev.get("isSet") == "true"
+    assert root.find(".//UnknownSibling") is not None
+
+
+# ---------------------------------------------------------------------------
+# Body patch: structured builder + preservation merge (build is mocked so the
+# test focuses on safe-edit's merge + push orchestration, not builder fields).
+# ---------------------------------------------------------------------------
+
+def test_body_patch_preserves_encrypted_and_unknown(monkeypatch):
+    _spy_compare(monkeypatch)
+
+    def _fake_build(boomi_client, comp, payload, **kwargs):
+        return {"_success": True, "built_xml": _DESIRED_DB_CONN, "policy": _DB_POLICY}
+
+    monkeypatch.setattr(safe_edit_component, "build_structured_update_xml", _fake_build)
+    client = _FakeClient()
+    patch = {"component_type": "connector-settings", "config": {"host": "db.internal"}}
+
+    prep = prepare_component_edit_action(client, "prof", COMPONENT_ID, patch)
+    assert prep["_success"] is True
+    assert prep["update_mode"] == "read_merge_write"
+    assert client.component.pushed == []
+
+    res = apply_component_edit_action(
+        client, "prof", COMPONENT_ID, patch, prep["confirmation_token"], confirm_apply=True
+    )
+    assert res["_success"] is True
+    pushed_xml = client.component.pushed[-1][1]
+    root = ET.fromstring(pushed_xml)
+    # Owned attr replaced from desired; unknown root attr preserved from current.
+    assert root.get("name") == "conn-renamed"
+    assert root.get("futureFlag") == "opaque-value"
+    # Encrypted secret + unknown sibling survive the merge.
+    ev = root.find("bns:encryptedValues/bns:encryptedValue", NS)
+    assert ev is not None and ev.get("isSet") == "true"
+    assert root.find(".//UnknownSibling") is not None
+
+
+def test_transform_map_body_without_map_context_errors():
+    client = _FakeClient(_CURRENT_MAP)
+    patch = {"config": {"map_type": "direct", "mappings": [{"from": "a", "to": "b"}]}}
+    prep = prepare_component_edit_action(client, "prof", COMPONENT_ID, patch)
+    assert prep["_success"] is False
+    assert prep["error_code"] == "MAP_PROFILE_INDEX_UNAVAILABLE"
+    assert client.component.pushed == []
+
+
+# ---------------------------------------------------------------------------
+# Drift / token integrity aborts
+# ---------------------------------------------------------------------------
+
+def test_drift_detected_aborts(monkeypatch):
+    _spy_compare(monkeypatch)
+    client = _FakeClient()
+    patch = {"config": {"name": "conn-renamed"}}
+    token = _prepare_then_token(client, patch)
+
+    # Simulate someone else editing the component after preview.
+    client.component._version += 1
+
+    res = apply_component_edit_action(
+        client, "prof", COMPONENT_ID, patch, token, confirm_apply=True
+    )
+    assert res["_success"] is False
+    assert res["error_code"] == "COMPONENT_EDIT_DRIFT_DETECTED"
+    assert res["current_version"] == 4
+    assert res["expected_version"] == 3
+    assert client.component.pushed == []
+
+
+def test_patch_mismatch_aborts():
+    client = _FakeClient()
+    token = _prepare_then_token(client, {"config": {"name": "conn-renamed"}})
+    # Apply a DIFFERENT patch than the one the token fingerprints.
+    res = apply_component_edit_action(
+        client, "prof", COMPONENT_ID,
+        {"config": {"name": "totally-different"}}, token, confirm_apply=True,
+    )
+    assert res["_success"] is False
+    assert res["error_code"] == "COMPONENT_EDIT_PATCH_MISMATCH"
+    assert client.component.pushed == []
+
+
+def test_malformed_token_rejected():
+    client = _FakeClient()
+    res = apply_component_edit_action(
+        client, "prof", COMPONENT_ID,
+        {"config": {"name": "conn-renamed"}}, "!!!not-base64!!!", confirm_apply=True,
+    )
+    assert res["_success"] is False
+    assert res["error_code"] == "COMPONENT_EDIT_TOKEN_INVALID"
+    assert client.component.pushed == []
+
+
+def test_token_for_other_component_rejected():
+    client = _FakeClient()
+    token = _prepare_then_token(client, {"config": {"name": "conn-renamed"}})
+    res = apply_component_edit_action(
+        client, "prof", "different-id",
+        {"config": {"name": "conn-renamed"}}, token, confirm_apply=True,
+    )
+    assert res["_success"] is False
+    assert res["error_code"] == "COMPONENT_EDIT_TOKEN_INVALID"

--- a/tests/test_component_safe_edit_wrapper.py
+++ b/tests/test_component_safe_edit_wrapper.py
@@ -1,0 +1,186 @@
+"""Wrapper tests for the M9.7 safe-edit MCP tools (#97).
+
+Exercises the FastMCP registration of prepare_component_edit / apply_component_edit:
+annotations, parameter contract, JSON-before-credentials parsing, and the
+confirm_apply gate firing before any credential access.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = str(Path(__file__).resolve().parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+# Force local mode before importing server.
+os.environ["BOOMI_LOCAL"] = "true"
+
+import server  # noqa: E402
+
+
+def _run_async(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _payload(result):
+    assert getattr(result, "content", None), f"call_tool returned no content: {result!r}"
+    return json.loads(result.content[0].text)
+
+
+def _boom_creds(*_args, **_kwargs):
+    raise AssertionError("credentials were accessed before the input gate")
+
+
+# ---------------------------------------------------------------------------
+# Registration + annotations + parameter contract
+# ---------------------------------------------------------------------------
+
+def test_both_tools_registered_with_correct_annotations():
+    prep = _run_async(server.mcp.get_tool("prepare_component_edit"))
+    apply = _run_async(server.mcp.get_tool("apply_component_edit"))
+
+    assert prep.annotations.readOnlyHint is True
+    assert prep.annotations.openWorldHint is True
+
+    assert apply.annotations.readOnlyHint is False
+    assert apply.annotations.destructiveHint is True
+    assert apply.annotations.openWorldHint is True
+
+
+def test_parameter_contract():
+    prep = _run_async(server.mcp.get_tool("prepare_component_edit"))
+    prep_props = prep.parameters["properties"]
+    assert {"profile", "component_id", "patch", "max_diff_lines"} <= set(prep_props)
+    assert "max_diff_lines" not in prep.parameters.get("required", [])
+
+    apply = _run_async(server.mcp.get_tool("apply_component_edit"))
+    apply_props = apply.parameters["properties"]
+    assert {"profile", "component_id", "patch", "confirmation_token", "confirm_apply"} <= set(apply_props)
+    # confirm_apply defaults to false, so it is not required.
+    assert "confirm_apply" not in apply.parameters.get("required", [])
+
+
+def test_docstrings_document_workflow():
+    prep = _run_async(server.mcp.get_tool("prepare_component_edit"))
+    apply = _run_async(server.mcp.get_tool("apply_component_edit"))
+    assert "confirmation_token" in (prep.description or "")
+    assert "READ-ONLY" in (prep.description or "")
+    assert "confirm_apply=true" in (apply.description or "")
+    assert "drift" in (apply.description or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Input validation happens BEFORE any credential access
+# ---------------------------------------------------------------------------
+
+def test_prepare_invalid_json_before_credentials(monkeypatch):
+    monkeypatch.setattr(server, "get_secret", _boom_creds)
+    result = _run_async(
+        server.mcp.call_tool(
+            "prepare_component_edit",
+            {"profile": "p", "component_id": "c", "patch": "{not json"},
+        )
+    )
+    payload = _payload(result)
+    assert payload["_success"] is False
+    assert "Invalid patch" in payload["error"]
+    assert payload["boomi_mutation"] is False
+
+
+def test_prepare_non_object_patch_rejected(monkeypatch):
+    monkeypatch.setattr(server, "get_secret", _boom_creds)
+    result = _run_async(
+        server.mcp.call_tool(
+            "prepare_component_edit",
+            {"profile": "p", "component_id": "c", "patch": "[1, 2, 3]"},
+        )
+    )
+    payload = _payload(result)
+    assert payload["_success"] is False
+    assert "JSON object" in payload["error"]
+
+
+def test_apply_confirmation_gate_before_credentials(monkeypatch):
+    monkeypatch.setattr(server, "get_secret", _boom_creds)
+    result = _run_async(
+        server.mcp.call_tool(
+            "apply_component_edit",
+            {
+                "profile": "p",
+                "component_id": "c",
+                "patch": json.dumps({"config": {"name": "x"}}),
+                "confirmation_token": "tok",
+                "confirm_apply": False,
+            },
+        )
+    )
+    payload = _payload(result)
+    assert payload["_success"] is False
+    assert payload["error_code"] == "COMPONENT_EDIT_CONFIRMATION_REQUIRED"
+    assert payload["boomi_mutation"] is False
+
+
+def test_apply_invalid_json_before_credentials(monkeypatch):
+    monkeypatch.setattr(server, "get_secret", _boom_creds)
+    result = _run_async(
+        server.mcp.call_tool(
+            "apply_component_edit",
+            {
+                "profile": "p",
+                "component_id": "c",
+                "patch": "{not json",
+                "confirmation_token": "tok",
+                "confirm_apply": True,
+            },
+        )
+    )
+    payload = _payload(result)
+    assert payload["_success"] is False
+    assert "Invalid patch" in payload["error"]
+    assert payload["boomi_mutation"] is False
+
+
+# ---------------------------------------------------------------------------
+# Happy path: wrapper parses the patch and hands the dict to the action,
+# returning the action's result (incl. confirmation_token).
+# ---------------------------------------------------------------------------
+
+def test_prepare_passes_parsed_patch_and_returns_token(monkeypatch):
+    seen = {}
+
+    def _fake_prepare(sdk, profile, component_id, patch_data, max_diff_lines):
+        seen["patch_data"] = patch_data
+        seen["max_diff_lines"] = max_diff_lines
+        return {"_success": True, "confirmation_token": "TKN", "boomi_mutation": False}
+
+    monkeypatch.setattr(server, "get_current_user", lambda: "tester")
+    monkeypatch.setattr(server, "get_secret", lambda *a, **k: {
+        "account_id": "acc", "username": "u", "password": "pw",
+    })
+    monkeypatch.setattr(server, "Boomi", lambda **kw: object())
+    monkeypatch.setattr(server, "prepare_component_edit_action", _fake_prepare)
+
+    result = _run_async(
+        server.mcp.call_tool(
+            "prepare_component_edit",
+            {
+                "profile": "p",
+                "component_id": "c",
+                "patch": json.dumps({"config": {"name": "x"}}),
+            },
+        )
+    )
+    payload = _payload(result)
+    assert payload["_success"] is True
+    assert payload["confirmation_token"] == "TKN"
+    assert seen["patch_data"] == {"config": {"name": "x"}}
+    assert seen["max_diff_lines"] == 200

--- a/tests/test_meta_tools_list_capabilities.py
+++ b/tests/test_meta_tools_list_capabilities.py
@@ -494,3 +494,63 @@ def test_new_doctrine_hints_present():
                 "reuse_connections", "avoid_scripts"):
         assert key in hints, f"hints missing {key}"
     assert "confirm_write=true" in hints["raw_write_gate"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #97 (M9.7) — safe existing-component edit workflow discoverability
+# ---------------------------------------------------------------------------
+
+_SAFE_EDIT_TOOLS = ("prepare_component_edit", "apply_component_edit")
+
+
+def test_safe_edit_tools_in_capabilities():
+    tools = list_capabilities_action()["tools"]
+    for name in _SAFE_EDIT_TOOLS:
+        assert name in tools, f"{name} missing from list_capabilities tools"
+        assert tools[name]["category"] == "Components"
+    # prepare is read-only; apply mutates.
+    assert tools["prepare_component_edit"]["read_only"] is True
+    assert tools["apply_component_edit"]["read_only"] is False
+    # apply documents the confirmation gate.
+    assert "confirm_apply" in tools["apply_component_edit"]["parameters"]
+
+
+def test_safe_edit_workflow_surfaced_unfiltered():
+    wf = list_capabilities_action()["workflows"]
+    assert "safe_edit_existing_component" in wf
+    steps = " ".join(wf["safe_edit_existing_component"]["steps"])
+    assert "prepare_component_edit(" in steps
+    assert "apply_component_edit(" in steps
+    assert "confirm_apply=true" in steps
+
+
+def test_safe_edit_tools_filtered_when_not_registered():
+    only = {"build_integration", "get_schema_template", "list_boomi_profiles"}
+    catalog = list_capabilities_action(available_tools=only)
+    for name in _SAFE_EDIT_TOOLS:
+        assert name not in catalog["tools"]
+
+
+def test_safe_edit_workflow_dropped_when_apply_absent():
+    """The workflow references apply_component_edit; absent that tool the
+    available_tools filter must drop the whole workflow (repo discipline)."""
+    only = {
+        "query_components",
+        "prepare_component_edit",
+        "analyze_component",
+        "list_boomi_profiles",
+    }
+    catalog = list_capabilities_action(available_tools=only)
+    assert "safe_edit_existing_component" not in catalog["workflows"]
+
+
+def test_safe_edit_workflow_preserved_when_all_tools_present():
+    only = {
+        "query_components",
+        "prepare_component_edit",
+        "apply_component_edit",
+        "analyze_component",
+        "list_boomi_profiles",
+    }
+    catalog = list_capabilities_action(available_tools=only)
+    assert "safe_edit_existing_component" in catalog["workflows"]

--- a/tests/test_schema_template_unknown_op.py
+++ b/tests/test_schema_template_unknown_op.py
@@ -17,7 +17,7 @@ RESOURCE_CASES = [
     ("trading_partner", ["create", "list", "update"]),
     ("process", ["create", "list"]),
     ("integration", ["plan", "apply", "verify"]),
-    ("component", ["create", "search", "clone", "compare_versions"]),
+    ("component", ["create", "search", "clone", "compare_versions", "safe_edit"]),
     ("environment", ["create"]),
     ("package", ["create", "deploy"]),
     ("execution_request", ["execute"]),
@@ -61,3 +61,14 @@ def test_unknown_resource_type():
     assert result["error"] == "Unknown resource_type: __nonexistent__"
     assert "valid_types" in result
     assert result["error_code"] == SCHEMA_LOOKUP_FAILED
+
+
+def test_component_safe_edit_operation_returns_template():
+    """The new M9.7 safe_edit operation must resolve to a structured template."""
+    result = get_schema_template_action(resource_type="component", operation="safe_edit")
+
+    assert result["_success"] is True
+    assert result["operation"] == "safe_edit"
+    assert "prepare_component_edit (read-only preview)" in result["tools"]
+    assert "apply_component_edit (confirmed write)" in result["tools"]
+    assert "COMPONENT_EDIT_DRIFT_DETECTED" in result["error_codes"]


### PR DESCRIPTION
Closes #97

Adds a two-phase safe existing-component edit workflow: read-only prepare_component_edit (pull + structured patch + diff + confirmation token, no mutation) and confirmed apply_component_edit (re-fetch, abort on drift/patch-mismatch, push via typed builder + #45/#50 preservation merge, version comparison). Backed by a new shared build_structured_update_xml helper, COMPONENT_EDIT_* error codes, and full schema/capability/workflow discoverability. Rollback stays deferred.

Architect review: clean after 1 round(s).